### PR TITLE
Change min req of python-sdk to python 3.7 from python 3.8 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM python:3.8-buster
+FROM python:3.7-buster
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VER: 3.8
+      PYTHON_VER: 3.7
       TWINE_USERNAME: ${{ secrets.PYPI_UPLOAD_USER }}
       TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         tox -e type
     - name: Run unit-tests
       run: |
-        tox -e py38
+        tox -e py37
     - name: Build and publish Dapr Python SDK
       if: github.event_name != 'pull_request'
       run: |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This includes the following packages:
 ### Prerequisites
 
 * [Install Dapr standalone mode](https://github.com/dapr/cli#install-dapr-on-your-local-machine-standalone)
-* [Install Python 3.8+](https://www.python.org/downloads/)
+* [Install Python 3.7+](https://www.python.org/downloads/)
 
 ### Install Dapr python sdk
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip3 install -r dev-requirements.txt
 4. Run unit-test
 
 ```bash
-tox -e py38
+tox -e py37
 ```
 
 5. Run type check

--- a/examples/demo_actor/README.md
+++ b/examples/demo_actor/README.md
@@ -11,7 +11,7 @@ This document describes how to create an Actor(DemoActor) and invoke its methods
 ## Prerequisites
 
 * [Install Dapr standalone mode](https://github.com/dapr/cli#install-dapr-on-your-local-machine-standalone)
-* [Install Python 3.8+](https://www.python.org/downloads/)
+* [Install Python 3.7+](https://www.python.org/downloads/)
 
 ## Install Dapr SDK
 

--- a/examples/demo_actor/demo_actor/Dockerfile
+++ b/examples/demo_actor/demo_actor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM python:3.8-slim-buster
+FROM python:3.7-slim-buster
 
 WORKDIR /app
 COPY . . 

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -10,13 +10,13 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.7
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.7
 packages = find:
 include_package_data = true
 zip_safe = false

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.7
 warn_unused_configs = True
 warn_redundant_casts = True
 show_error_codes = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,13 +10,13 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.7
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.7
 packages = find:
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk

--- a/tests/actor/fake_actor_classes.py
+++ b/tests/actor/fake_actor_classes.py
@@ -10,6 +10,42 @@ from datetime import timedelta
 from dapr.actor.runtime.actor import Actor
 from dapr.actor.runtime.remindable import Remindable
 from dapr.actor.actor_interface import ActorInterface, actormethod
+from dapr.clients import DaprActorClientBase
+
+# Fake Dapr Actor Client Base Class for testing
+class FakeDaprActorClientBase(DaprActorClientBase):
+    async def register_reminder(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        ...
+
+    async def unregister_reminder(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        ...
+
+    async def register_timer(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        ...
+
+    async def unregister_timer(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        ...
+
+class FakeDaprActorClient(FakeDaprActorClientBase):
+
+    async def register_reminder(self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        pass
+
+    async def unregister_reminder(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+            pass
+
+    async def register_timer(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+            pass
+
+    async def unregister_timer(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+            pass
 
 
 # Fake Simple Actor Class for testing

--- a/tests/actor/fake_actor_classes.py
+++ b/tests/actor/fake_actor_classes.py
@@ -6,6 +6,7 @@ Licensed under the MIT License.
 """
 
 from datetime import timedelta
+from typing import Optional
 
 from dapr.actor.runtime.actor import Actor
 from dapr.actor.runtime.remindable import Remindable
@@ -14,6 +15,20 @@ from dapr.clients import DaprActorClientBase
 
 # Fake Dapr Actor Client Base Class for testing
 class FakeDaprActorClientBase(DaprActorClientBase):
+    async def invoke_method(
+            self, actor_type: str, actor_id: str,
+            method: str, data: Optional[bytes] = None) -> bytes:
+        ...
+
+    async def save_state_transactionally(
+            self, actor_type: str, actor_id: str,
+            data: bytes) -> None:
+        ...
+
+    async def get_state(
+            self, actor_type: str, actor_id: str, name: str) -> bytes:
+        ...
+
     async def register_reminder(
             self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
         ...
@@ -31,6 +46,19 @@ class FakeDaprActorClientBase(DaprActorClientBase):
         ...
 
 class FakeDaprActorClient(FakeDaprActorClientBase):
+    async def invoke_method(
+            self, actor_type: str, actor_id: str,
+            method: str, data: Optional[bytes] = None) -> bytes:
+            return b'"expected_response"'
+
+    async def save_state_transactionally(
+            self, actor_type: str, actor_id: str,
+            data: bytes) -> None:
+        pass
+
+    async def get_state(
+            self, actor_type: str, actor_id: str, name: str) -> bytes:
+        return b'"expected_response"'
 
     async def register_reminder(self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
         pass

--- a/tests/actor/fake_actor_classes.py
+++ b/tests/actor/fake_actor_classes.py
@@ -6,78 +6,10 @@ Licensed under the MIT License.
 """
 
 from datetime import timedelta
-from typing import Optional
 
 from dapr.actor.runtime.actor import Actor
 from dapr.actor.runtime.remindable import Remindable
 from dapr.actor.actor_interface import ActorInterface, actormethod
-from dapr.clients import DaprActorClientBase
-
-
-# Fake Dapr Actor Client Base Class for testing
-class FakeDaprActorClientBase(DaprActorClientBase):
-    async def invoke_method(
-            self, actor_type: str, actor_id: str,
-            method: str, data: Optional[bytes] = None) -> bytes:
-        ...
-
-    async def save_state_transactionally(
-            self, actor_type: str, actor_id: str,
-            data: bytes) -> None:
-        ...
-
-    async def get_state(
-            self, actor_type: str, actor_id: str, name: str) -> bytes:
-        ...
-
-    async def register_reminder(
-            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
-        ...
-
-    async def unregister_reminder(
-            self, actor_type: str, actor_id: str, name: str) -> None:
-        ...
-
-    async def register_timer(
-            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
-        ...
-
-    async def unregister_timer(
-            self, actor_type: str, actor_id: str, name: str) -> None:
-        ...
-
-
-class FakeDaprActorClient(FakeDaprActorClientBase):
-    async def invoke_method(
-            self, actor_type: str, actor_id: str,
-            method: str, data: Optional[bytes] = None) -> bytes:
-        return b'"expected_response"'
-
-    async def save_state_transactionally(
-            self, actor_type: str, actor_id: str,
-            data: bytes) -> None:
-        pass
-
-    async def get_state(
-            self, actor_type: str, actor_id: str, name: str) -> bytes:
-        return b'"expected_response"'
-
-    async def register_reminder(
-            self, actor_type: str, actor_id: str,
-            name: str, data: bytes) -> None:
-        pass
-
-    async def unregister_reminder(
-            self, actor_type: str, actor_id: str, name: str) -> None:
-        pass
-
-    async def register_timer(
-            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
-        pass
-
-    async def unregister_timer(
-            self, actor_type: str, actor_id: str, name: str) -> None:
-        pass
 
 
 # Fake Simple Actor Class for testing

--- a/tests/actor/fake_actor_classes.py
+++ b/tests/actor/fake_actor_classes.py
@@ -13,6 +13,7 @@ from dapr.actor.runtime.remindable import Remindable
 from dapr.actor.actor_interface import ActorInterface, actormethod
 from dapr.clients import DaprActorClientBase
 
+
 # Fake Dapr Actor Client Base Class for testing
 class FakeDaprActorClientBase(DaprActorClientBase):
     async def invoke_method(
@@ -45,11 +46,12 @@ class FakeDaprActorClientBase(DaprActorClientBase):
             self, actor_type: str, actor_id: str, name: str) -> None:
         ...
 
+
 class FakeDaprActorClient(FakeDaprActorClientBase):
     async def invoke_method(
             self, actor_type: str, actor_id: str,
             method: str, data: Optional[bytes] = None) -> bytes:
-            return b'"expected_response"'
+        return b'"expected_response"'
 
     async def save_state_transactionally(
             self, actor_type: str, actor_id: str,
@@ -60,20 +62,22 @@ class FakeDaprActorClient(FakeDaprActorClientBase):
             self, actor_type: str, actor_id: str, name: str) -> bytes:
         return b'"expected_response"'
 
-    async def register_reminder(self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+    async def register_reminder(
+            self, actor_type: str, actor_id: str,
+            name: str, data: bytes) -> None:
         pass
 
     async def unregister_reminder(
             self, actor_type: str, actor_id: str, name: str) -> None:
-            pass
+        pass
 
     async def register_timer(
             self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
-            pass
+        pass
 
     async def unregister_timer(
             self, actor_type: str, actor_id: str, name: str) -> None:
-            pass
+        pass
 
 
 # Fake Simple Actor Class for testing

--- a/tests/actor/fake_client.py
+++ b/tests/actor/fake_client.py
@@ -1,0 +1,69 @@
+
+from dapr.clients import DaprActorClientBase
+from typing import Optional
+
+
+# Fake Dapr Actor Client Base Class for testing
+class FakeDaprActorClientBase(DaprActorClientBase):
+    async def invoke_method(
+            self, actor_type: str, actor_id: str,
+            method: str, data: Optional[bytes] = None) -> bytes:
+        ...
+
+    async def save_state_transactionally(
+            self, actor_type: str, actor_id: str,
+            data: bytes) -> None:
+        ...
+
+    async def get_state(
+            self, actor_type: str, actor_id: str, name: str) -> bytes:
+        ...
+
+    async def register_reminder(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        ...
+
+    async def unregister_reminder(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        ...
+
+    async def register_timer(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        ...
+
+    async def unregister_timer(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        ...
+
+
+class FakeDaprActorClient(FakeDaprActorClientBase):
+    async def invoke_method(
+            self, actor_type: str, actor_id: str,
+            method: str, data: Optional[bytes] = None) -> bytes:
+        return b'"expected_response"'
+
+    async def save_state_transactionally(
+            self, actor_type: str, actor_id: str,
+            data: bytes) -> None:
+        pass
+
+    async def get_state(
+            self, actor_type: str, actor_id: str, name: str) -> bytes:
+        return b'"expected_response"'
+
+    async def register_reminder(
+            self, actor_type: str, actor_id: str,
+            name: str, data: bytes) -> None:
+        pass
+
+    async def unregister_reminder(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        pass
+
+    async def register_timer(
+            self, actor_type: str, actor_id: str, name: str, data: bytes) -> None:
+        pass
+
+    async def unregister_timer(
+            self, actor_type: str, actor_id: str, name: str) -> None:
+        pass

--- a/tests/actor/fake_client.py
+++ b/tests/actor/fake_client.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+"""
 
 from dapr.clients import DaprActorClientBase
 from typing import Optional

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 """
 
 import unittest
-import asyncio
 
 from unittest import mock
 from datetime import timedelta
@@ -30,6 +29,7 @@ from tests.actor.utils import (
     _async_mock,
     _run
 )
+
 
 class ActorTests(unittest.TestCase):
     def setUp(self):
@@ -99,8 +99,12 @@ class ActorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder', new=_async_mock(return_value=b'"ok"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder', new=_async_mock(return_value=b'"ok"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder',
+        new=_async_mock(return_value=b'"ok"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder',
+        new=_async_mock(return_value=b'"ok"'))
     def test_register_reminder(self):
 
         test_actor_id = ActorId('test_id')
@@ -127,8 +131,12 @@ class ActorTests(unittest.TestCase):
         test_client.unregister_reminder.mock.assert_called_with(
             'FakeSimpleReminderActor', 'test_id', 'test_reminder')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer', new=_async_mock(return_value=b'"ok"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer', new=_async_mock(return_value=b'"ok"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer',
+        new=_async_mock(return_value=b'"ok"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer',
+        new=_async_mock(return_value=b'"ok"'))
     def test_register_timer(self):
 
         test_actor_id = ActorId('test_id')

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -6,9 +6,10 @@ Licensed under the MIT License.
 """
 
 import unittest
+import asyncio
 
+from unittest import mock
 from datetime import timedelta
-from unittest.mock import AsyncMock
 
 from dapr.actor.id import ActorId
 from dapr.actor.runtime.config import ActorRuntimeConfig
@@ -18,20 +19,32 @@ from dapr.actor.runtime._type_information import ActorTypeInformation
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
+    FakeDaprActorClient,
     FakeSimpleActor,
     FakeSimpleReminderActor,
     FakeSimpleTimerActor,
     FakeMultiInterfacesActor,
 )
 
+def async_mock(*args, **kwargs):
+    m = mock.MagicMock(*args, **kwargs)
 
-class ActorTests(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
+    async def mock_coro(*args, **kwargs):
+        return m(*args, **kwargs)
+
+    mock_coro.mock = m
+    return mock_coro
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+class ActorTests(unittest.TestCase):
+    def setUp(self):
         ActorRuntime._actor_managers = {}
         ActorRuntime.set_actor_config(ActorRuntimeConfig())
         self._serializer = DefaultJSONSerializer()
-        await ActorRuntime.register_actor(FakeSimpleActor)
-        await ActorRuntime.register_actor(FakeMultiInterfacesActor)
+        _run(ActorRuntime.register_actor(FakeSimpleActor))
+        _run(ActorRuntime.register_actor(FakeMultiInterfacesActor))
 
     def test_get_registered_actor_types(self):
         actor_types = ActorRuntime.get_registered_actor_types()
@@ -60,7 +73,7 @@ class ActorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(timedelta(minutes=1), config._drain_ongoing_call_timeout)
         self.assertEqual(2, len(config._entities))
 
-    async def test_entities_update(self):
+    def test_entities_update(self):
         # Clean up managers
         ActorRuntime._actor_managers = {}
         ActorRuntime.set_actor_config(ActorRuntimeConfig())
@@ -69,90 +82,90 @@ class ActorTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             config._entities.index(FakeSimpleActor.__name__)
 
-        await ActorRuntime.register_actor(FakeSimpleActor)
+        _run(ActorRuntime.register_actor(FakeSimpleActor))
         config = ActorRuntime.get_actor_config()
         self.assertTrue(config._entities.index(FakeSimpleActor.__name__) >= 0)
 
-    async def test_dispatch(self):
-        await ActorRuntime.register_actor(FakeMultiInterfacesActor)
+    def test_dispatch(self):
+        _run(ActorRuntime.register_actor(FakeMultiInterfacesActor))
 
         request_body = {
             "message": "hello dapr",
         }
 
         test_request_body = self._serializer.serialize(request_body)
-        response = await ActorRuntime.dispatch(
+        response = _run(ActorRuntime.dispatch(
             FakeMultiInterfacesActor.__name__, 'test-id',
-            "ActionMethod", test_request_body)
+            "ActionMethod", test_request_body))
 
         self.assertEqual(b'"hello dapr"', response)
 
-        await ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id')
+        _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
         # Ensure test-id is deactivated
         with self.assertRaises(ValueError):
-            await ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id')
+            _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
-    async def test_register_reminder(self):
-        fake_client = AsyncMock()
-        fake_client.register_reminder.return_value = b'"ok"'
-        fake_client.unregister_reminder.return_value = b'"ok"'
+    @mock.patch('FakeDaprActorClient.register_reminder', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('FakeDaprActorClient.unregister_reminder', new=async_mock(return_value=b'"ok"'))
+    def test_register_reminder(self):
 
         test_actor_id = ActorId('test_id')
         test_type_info = ActorTypeInformation.create(FakeSimpleReminderActor)
+        test_client = FakeDaprActorClient
         ctx = ActorRuntimeContext(
             test_type_info, self._serializer,
-            self._serializer, fake_client)
+            self._serializer, test_client)
         test_actor = FakeSimpleReminderActor(ctx, test_actor_id)
 
         # register reminder
-        await test_actor.register_reminder(
+        _run(test_actor.register_reminder(
             'test_reminder', b'reminder_message',
-            timedelta(seconds=1), timedelta(seconds=1))
-        fake_client.register_reminder.assert_called_once()
-        fake_client.register_reminder.assert_called_with(
+            timedelta(seconds=1), timedelta(seconds=1)))
+        test_client.register_reminder.mock.assert_called_once()
+        test_client.register_reminder.mock.assert_called_with(
             'FakeSimpleReminderActor', 'test_id',
             'test_reminder',
             b'{"name":"test_reminder","dueTime":"0h0m1s","period":"0h0m1s","data":"cmVtaW5kZXJfbWVzc2FnZQ=="}')  # noqa E501
 
         # unregister reminder
-        await test_actor.unregister_reminder('test_reminder')
-        fake_client.unregister_reminder.assert_called_once()
-        fake_client.unregister_reminder.assert_called_with(
+        _run(test_actor.unregister_reminder('test_reminder'))
+        test_client.unregister_reminder.mock.assert_called_once()
+        test_client.unregister_reminder.mock.assert_called_with(
             'FakeSimpleReminderActor', 'test_id', 'test_reminder')
 
-    async def test_register_timer(self):
-        fake_client = AsyncMock()
-        fake_client.register_timer.return_value = b'"ok"'
-        fake_client.unregister_timer.return_value = b'"ok"'
+    @mock.patch('FakeDaprActorClient.register_timer', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('FakeDaprActorClient.unregister_timer', new=async_mock(return_value=b'"ok"'))
+    def test_register_timer(self):
 
         test_actor_id = ActorId('test_id')
         test_type_info = ActorTypeInformation.create(FakeSimpleTimerActor)
+        test_client = FakeDaprActorClient
         ctx = ActorRuntimeContext(
             test_type_info, self._serializer,
-            self._serializer, fake_client)
+            self._serializer, test_client)
         test_actor = FakeSimpleTimerActor(ctx, test_actor_id)
 
         # register timer
-        await test_actor.register_timer(
+        _run(test_actor.register_timer(
             'test_timer', test_actor.timer_callback,
-            "timer call", timedelta(seconds=1), timedelta(seconds=1))
-        fake_client.register_timer.assert_called_once()
-        fake_client.register_timer.assert_called_with(
+            "timer call", timedelta(seconds=1), timedelta(seconds=1)))
+        test_client.mock.register_timer.assert_called_once()
+        test_client.mock.register_timer.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer',
             b'{"dueTime":"0h0m1s","period":"0h0m1s"}')
         self.assertTrue('test_timer' in test_actor._timers)
         self.assertEqual(1, len(test_actor._timers))
 
         # unregister timer
-        await test_actor.unregister_timer('test_timer')
-        fake_client.unregister_timer.assert_called_once()
-        fake_client.unregister_timer.assert_called_with(
+        _run(test_actor.unregister_timer('test_timer'))
+        test_client.mock.unregister_timer.assert_called_once()
+        test_client.mock.unregister_timer.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer')
         self.assertEqual(0, len(test_actor._timers))
 
         # register timer without timer name
-        await test_actor.register_timer(
+        _run(test_actor.register_timer(
             None, test_actor.timer_callback,
-            "timer call", timedelta(seconds=1), timedelta(seconds=1))
+            "timer call", timedelta(seconds=1), timedelta(seconds=1)))
         self.assertEqual("test_id_Timer_1", list(test_actor._timers)[0])

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -106,8 +106,8 @@ class ActorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
-    @mock.patch('FakeDaprActorClient.register_reminder', new=async_mock(return_value=b'"ok"'))
-    @mock.patch('FakeDaprActorClient.unregister_reminder', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder', new=async_mock(return_value=b'"ok"'))
     def test_register_reminder(self):
 
         test_actor_id = ActorId('test_id')
@@ -134,8 +134,8 @@ class ActorTests(unittest.TestCase):
         test_client.unregister_reminder.mock.assert_called_with(
             'FakeSimpleReminderActor', 'test_id', 'test_reminder')
 
-    @mock.patch('FakeDaprActorClient.register_timer', new=async_mock(return_value=b'"ok"'))
-    @mock.patch('FakeDaprActorClient.unregister_timer', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer', new=async_mock(return_value=b'"ok"'))
     def test_register_timer(self):
 
         test_actor_id = ActorId('test_id')
@@ -150,8 +150,8 @@ class ActorTests(unittest.TestCase):
         _run(test_actor.register_timer(
             'test_timer', test_actor.timer_callback,
             "timer call", timedelta(seconds=1), timedelta(seconds=1)))
-        test_client.mock.register_timer.assert_called_once()
-        test_client.mock.register_timer.assert_called_with(
+        test_client.register_timer.mock.assert_called_once()
+        test_client.register_timer.mock.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer',
             b'{"dueTime":"0h0m1s","period":"0h0m1s"}')
         self.assertTrue('test_timer' in test_actor._timers)
@@ -159,8 +159,8 @@ class ActorTests(unittest.TestCase):
 
         # unregister timer
         _run(test_actor.unregister_timer('test_timer'))
-        test_client.mock.unregister_timer.assert_called_once()
-        test_client.mock.unregister_timer.assert_called_with(
+        test_client.unregister_timer.mock.assert_called_once()
+        test_client.unregister_timer.mock.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer')
         self.assertEqual(0, len(test_actor._timers))
 

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -26,17 +26,10 @@ from tests.actor.fake_actor_classes import (
     FakeMultiInterfacesActor,
 )
 
-def async_mock(*args, **kwargs):
-    m = mock.MagicMock(*args, **kwargs)
-
-    async def mock_coro(*args, **kwargs):
-        return m(*args, **kwargs)
-
-    mock_coro.mock = m
-    return mock_coro
-
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from tests.actor.utils import (
+    _async_mock,
+    _run
+)
 
 class ActorTests(unittest.TestCase):
     def setUp(self):
@@ -106,8 +99,8 @@ class ActorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder', new=async_mock(return_value=b'"ok"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder', new=_async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder', new=_async_mock(return_value=b'"ok"'))
     def test_register_reminder(self):
 
         test_actor_id = ActorId('test_id')
@@ -134,8 +127,8 @@ class ActorTests(unittest.TestCase):
         test_client.unregister_reminder.mock.assert_called_with(
             'FakeSimpleReminderActor', 'test_id', 'test_reminder')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer', new=async_mock(return_value=b'"ok"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer', new=async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer', new=_async_mock(return_value=b'"ok"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer', new=_async_mock(return_value=b'"ok"'))
     def test_register_timer(self):
 
         test_actor_id = ActorId('test_id')

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -18,12 +18,13 @@ from dapr.actor.runtime._type_information import ActorTypeInformation
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
-    FakeDaprActorClient,
     FakeSimpleActor,
     FakeSimpleReminderActor,
     FakeSimpleTimerActor,
     FakeMultiInterfacesActor,
 )
+
+from tests.actor.fake_client import FakeDaprActorClient
 
 from tests.actor.utils import (
     _async_mock,
@@ -100,10 +101,10 @@ class ActorTests(unittest.TestCase):
             _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.register_reminder',
+        'tests.actor.fake_client.FakeDaprActorClient.register_reminder',
         new=_async_mock(return_value=b'"ok"'))
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_reminder',
+        'tests.actor.fake_client.FakeDaprActorClient.unregister_reminder',
         new=_async_mock(return_value=b'"ok"'))
     def test_register_reminder(self):
 
@@ -132,10 +133,10 @@ class ActorTests(unittest.TestCase):
             'FakeSimpleReminderActor', 'test_id', 'test_reminder')
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer',
+        'tests.actor.fake_client.FakeDaprActorClient.register_timer',
         new=_async_mock(return_value=b'"ok"'))
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.unregister_timer',
+        'tests.actor.fake_client.FakeDaprActorClient.unregister_timer',
         new=_async_mock(return_value=b'"ok"'))
     def test_register_timer(self):
 

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -7,9 +7,6 @@ Licensed under the MIT License.
 
 import unittest
 from datetime import timedelta
-import asyncio
-
-from unittest import mock
 
 from dapr.actor.id import ActorId
 from dapr.actor.runtime._type_information import ActorTypeInformation
@@ -22,10 +19,10 @@ from tests.actor.fake_actor_classes import (
     FakeMultiInterfacesActor,
     FakeSimpleActor,
     FakeSimpleReminderActor,
-    FakeSimpleTimerActor,
 )
 
 from tests.actor.utils import _run
+
 
 class ActorManagerTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -110,18 +110,18 @@ class ActorManagerReminderTests(unittest.TestCase):
 
 
 class ActorManagerTimerTests(unittest.TestCase):
+    def setUp(self):
+        self._serializer = DefaultJSONSerializer()
+
+        self._fake_client = FakeDaprActorClient
+
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer',
         new=_async_mock())
-    def setUp(self):
-        self._serializer = DefaultJSONSerializer()
-
-        self._fake_client = FakeDaprActorClient
-
-    async def test_fire_timer_success(self):
+    def test_fire_timer_success(self):
         test_actor_id = ActorId('testid')
         test_type_info = ActorTypeInformation.create(FakeSimpleTimerActor)
         ctx = ActorRuntimeContext(

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -7,7 +7,9 @@ Licensed under the MIT License.
 
 import unittest
 from datetime import timedelta
-from unittest.mock import AsyncMock
+import asyncio
+
+from unittest import mock
 
 from dapr.actor.id import ActorId
 from dapr.actor.runtime._type_information import ActorTypeInformation
@@ -16,67 +18,68 @@ from dapr.actor.runtime.context import ActorRuntimeContext
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
+    FakeDaprActorClient,
     FakeMultiInterfacesActor,
     FakeSimpleActor,
     FakeSimpleReminderActor,
     FakeSimpleTimerActor,
 )
 
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
 
-class ActorManagerTests(unittest.IsolatedAsyncioTestCase):
+class ActorManagerTests(unittest.TestCase):
     def setUp(self):
         self._test_type_info = ActorTypeInformation.create(FakeMultiInterfacesActor)
         self._serializer = DefaultJSONSerializer()
 
-        self._fake_client = AsyncMock()
-        self._fake_client.invoke_method.return_value = b'"expected_response"'
+        self._fake_client = FakeDaprActorClient
         self._runtime_ctx = ActorRuntimeContext(
             self._test_type_info, self._serializer,
             self._serializer, self._fake_client)
         self._manager = ActorManager(self._runtime_ctx)
 
-    async def test_activate_actor(self):
+    def test_activate_actor(self):
         """Activate ActorId(1)"""
         test_actor_id = ActorId('1')
-        await self._manager.activate_actor(test_actor_id)
+        _run(self._manager.activate_actor(test_actor_id))
 
         # assert
         self.assertEqual(test_actor_id, self._manager._active_actors[test_actor_id.id].id)
         self.assertTrue(self._manager._active_actors[test_actor_id.id].activated)
         self.assertFalse(self._manager._active_actors[test_actor_id.id].deactivated)
 
-    async def test_deactivate_actor(self):
+    def test_deactivate_actor(self):
         """Activate ActorId('2') and deactivate it"""
         test_actor_id = ActorId('2')
-        await self._manager.activate_actor(test_actor_id)
+        _run(self._manager.activate_actor(test_actor_id))
 
         # assert
         self.assertEqual(test_actor_id, self._manager._active_actors[test_actor_id.id].id)
         self.assertTrue(self._manager._active_actors[test_actor_id.id].activated)
         self.assertFalse(self._manager._active_actors[test_actor_id.id].deactivated)
 
-        await self._manager.deactivate_actor(test_actor_id)
+        _run(self._manager.deactivate_actor(test_actor_id))
         self.assertIsNone(self._manager._active_actors.get(test_actor_id.id))
 
-    async def test_dispatch_success(self):
+    def test_dispatch_success(self):
         """dispatch ActionMethod"""
         test_actor_id = ActorId('dispatch')
-        await self._manager.activate_actor(test_actor_id)
+        _run(self._manager.activate_actor(test_actor_id))
 
         request_body = {
             "message": "hello dapr",
         }
 
         test_request_body = self._serializer.serialize(request_body)
-        response = await self._manager.dispatch(test_actor_id, "ActionMethod", test_request_body)
+        response = _run(self._manager.dispatch(test_actor_id, "ActionMethod", test_request_body))
         self.assertEqual(b'"hello dapr"', response)
 
 
-class ActorManagerReminderTests(unittest.IsolatedAsyncioTestCase):
+class ActorManagerReminderTests(unittest.TestCase):
     def setUp(self):
         self._serializer = DefaultJSONSerializer()
-        self._fake_client = AsyncMock()
-        self._fake_client.invoke_method.return_value = b'"expected_response"'
+        self._fake_client = FakeDaprActorClient
 
         self._test_reminder_req = self._serializer.serialize({
             'name': 'test_reminder',
@@ -85,51 +88,21 @@ class ActorManagerReminderTests(unittest.IsolatedAsyncioTestCase):
             'data': 'cmVtaW5kZXJfc3RhdGU=',
         })
 
-    async def test_fire_reminder_for_non_reminderable(self):
+    def test_fire_reminder_for_non_reminderable(self):
         test_type_info = ActorTypeInformation.create(FakeSimpleActor)
         ctx = ActorRuntimeContext(
             test_type_info, self._serializer,
             self._serializer, self._fake_client)
         manager = ActorManager(ctx)
         with self.assertRaises(ValueError):
-            await manager.fire_reminder(ActorId('testid'), 'test_reminder', self._test_reminder_req)
+            _run(manager.fire_reminder(ActorId('testid'), 'test_reminder', self._test_reminder_req))
 
-    async def test_fire_reminder_success(self):
+    def test_fire_reminder_success(self):
         test_actor_id = ActorId('testid')
         test_type_info = ActorTypeInformation.create(FakeSimpleReminderActor)
         ctx = ActorRuntimeContext(
             test_type_info, self._serializer,
             self._serializer, self._fake_client)
         manager = ActorManager(ctx)
-        await manager.activate_actor(test_actor_id)
-        await manager.fire_reminder(test_actor_id, 'test_reminder', self._test_reminder_req)
-
-
-class ActorManagerTimerTests(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
-        self._serializer = DefaultJSONSerializer()
-
-        self._fake_client = AsyncMock()
-        self._fake_client.invoke_method.return_value = b'"expected_response"'
-        self._fake_client.register_timer.return_value = b'"ok"'
-
-    async def test_fire_timer_success(self):
-        test_actor_id = ActorId('testid')
-        test_type_info = ActorTypeInformation.create(FakeSimpleTimerActor)
-        ctx = ActorRuntimeContext(
-            test_type_info, self._serializer,
-            self._serializer, self._fake_client)
-        manager = ActorManager(ctx)
-
-        await manager.activate_actor(test_actor_id)
-        actor = manager._active_actors.get(test_actor_id.id, None)
-
-        # Setup timer
-        await actor.register_timer(
-            'test_timer', actor.timer_callback,
-            "timer call", timedelta(seconds=1), timedelta(seconds=1))
-
-        # Fire timer
-        await manager.fire_timer(test_actor_id, 'test_timer')
-
-        self.assertTrue(actor.timer_called)
+        _run(manager.activate_actor(test_actor_id))
+        _run(manager.fire_reminder(test_actor_id, 'test_reminder', self._test_reminder_req))

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -25,8 +25,7 @@ from tests.actor.fake_actor_classes import (
     FakeSimpleTimerActor,
 )
 
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from tests.actor.utils import _run
 
 class ActorManagerTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -16,12 +16,13 @@ from dapr.actor.runtime.context import ActorRuntimeContext
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
-    FakeDaprActorClient,
     FakeMultiInterfacesActor,
     FakeSimpleActor,
     FakeSimpleReminderActor,
     FakeSimpleTimerActor,
 )
+
+from tests.actor.fake_client import FakeDaprActorClient
 
 from tests.actor.utils import (
     _async_mock,
@@ -116,10 +117,10 @@ class ActorManagerTimerTests(unittest.TestCase):
         self._fake_client = FakeDaprActorClient
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        'tests.actor.fake_client.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.register_timer',
+        'tests.actor.fake_client.FakeDaprActorClient.register_timer',
         new=_async_mock())
     def test_fire_timer_success(self):
         test_actor_id = ActorId('testid')

--- a/tests/actor/test_actor_runtime.py
+++ b/tests/actor/test_actor_runtime.py
@@ -6,7 +6,9 @@ Licensed under the MIT License.
 """
 
 import unittest
+import asyncio
 
+from unittest import mock
 from datetime import timedelta
 
 from dapr.actor.runtime.runtime import ActorRuntime
@@ -18,14 +20,16 @@ from tests.actor.fake_actor_classes import (
     FakeMultiInterfacesActor,
 )
 
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
 
-class ActorRuntimeTests(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
+class ActorRuntimeTests(unittest.TestCase):
+    def setUp(self):
         ActorRuntime._actor_managers = {}
         ActorRuntime.set_actor_config(ActorRuntimeConfig())
         self._serializer = DefaultJSONSerializer()
-        await ActorRuntime.register_actor(FakeSimpleActor)
-        await ActorRuntime.register_actor(FakeMultiInterfacesActor)
+        _run(ActorRuntime.register_actor(FakeSimpleActor))
+        _run(ActorRuntime.register_actor(FakeMultiInterfacesActor))
 
     def test_get_registered_actor_types(self):
         actor_types = ActorRuntime.get_registered_actor_types()
@@ -55,7 +59,7 @@ class ActorRuntimeTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(timedelta(minutes=1), config._drain_ongoing_call_timeout)
         self.assertEqual(2, len(config._entities))
 
-    async def test_entities_update(self):
+    def test_entities_update(self):
         # Clean up managers
         ActorRuntime._actor_managers = {}
         ActorRuntime.set_actor_config(ActorRuntimeConfig())
@@ -64,26 +68,26 @@ class ActorRuntimeTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             config._entities.index(FakeSimpleActor.__name__)
 
-        await ActorRuntime.register_actor(FakeSimpleActor)
+        _run(ActorRuntime.register_actor(FakeSimpleActor))
         config = ActorRuntime.get_actor_config()
         self.assertTrue(config._entities.index(FakeSimpleActor.__name__) >= 0)
 
-    async def test_dispatch(self):
-        await ActorRuntime.register_actor(FakeMultiInterfacesActor)
+    def test_dispatch(self):
+        _run(ActorRuntime.register_actor(FakeMultiInterfacesActor))
 
         request_body = {
             "message": "hello dapr",
         }
 
         test_request_body = self._serializer.serialize(request_body)
-        response = await ActorRuntime.dispatch(
+        response = _run(ActorRuntime.dispatch(
             FakeMultiInterfacesActor.__name__, 'test-id',
-            "ActionMethod", test_request_body)
+            "ActionMethod", test_request_body))
 
         self.assertEqual(b'"hello dapr"', response)
 
-        await ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id')
+        _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))
 
         # Ensure test-id is deactivated
         with self.assertRaises(ValueError):
-            await ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id')
+            _run(ActorRuntime.deactivate(FakeMultiInterfacesActor.__name__, 'test-id'))

--- a/tests/actor/test_actor_runtime.py
+++ b/tests/actor/test_actor_runtime.py
@@ -20,8 +20,7 @@ from tests.actor.fake_actor_classes import (
     FakeMultiInterfacesActor,
 )
 
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from tests.actor.utils import _run
 
 class ActorRuntimeTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_actor_runtime.py
+++ b/tests/actor/test_actor_runtime.py
@@ -6,9 +6,7 @@ Licensed under the MIT License.
 """
 
 import unittest
-import asyncio
 
-from unittest import mock
 from datetime import timedelta
 
 from dapr.actor.runtime.runtime import ActorRuntime
@@ -21,6 +19,7 @@ from tests.actor.fake_actor_classes import (
 )
 
 from tests.actor.utils import _run
+
 
 class ActorRuntimeTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_client_proxy.py
+++ b/tests/actor/test_client_proxy.py
@@ -6,17 +6,31 @@ Licensed under the MIT License.
 """
 
 import unittest
-from unittest.mock import AsyncMock
+import asyncio
+
+from unittest import mock
 
 from dapr.actor.id import ActorId
 from dapr.actor.client.proxy import ActorProxy
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
+    FakeDaprActorClient,
     FakeMultiInterfacesActor,
     FakeActorCls2Interface,
 )
 
+def async_mock(*args, **kwargs):
+    m = mock.MagicMock(*args, **kwargs)
+
+    async def mock_coro(*args, **kwargs):
+        return m(*args, **kwargs)
+
+    mock_coro.mock = m
+    return mock_coro
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 class FakeActoryProxyFactory:
     def __init__(self, fake_client):
@@ -29,43 +43,72 @@ class FakeActoryProxyFactory:
                           actor_type, actor_id, DefaultJSONSerializer())
 
 
-class ActorProxyTests(unittest.IsolatedAsyncioTestCase):
-    def setUp(self):
-        # Create mock client
-        self._fake_client = AsyncMock()
-        self._fake_client.invoke_method.return_value = b'"expected_response"'
+class ActorProxyTests(unittest.TestCase):
 
-        self._fake_factory = FakeActoryProxyFactory(self._fake_client)
-        self._proxy = ActorProxy.create(
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    def test_invoke(self):
+        _fake_client = FakeDaprActorClient
+
+        _fake_factory = FakeActoryProxyFactory(_fake_client)
+        _proxy = ActorProxy.create(
             FakeMultiInterfacesActor.__name__,
             ActorId('fake-id'),
             FakeActorCls2Interface,
-            self._fake_factory)
+            _fake_factory)
 
-    async def test_invoke(self):
-        response = await self._proxy.invoke('ActionMethod', b'arg0')
+        response = _run(_proxy.invoke('ActionMethod', b'arg0'))
         self.assertEqual(b'"expected_response"', response)
-        self._fake_client.invoke_method.assert_called_once_with(
+        _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    async def test_invoke_no_arg(self):
-        response = await self._proxy.invoke('ActionMethodWithoutArg')
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    def test_invoke_no_arg(self):
+        _fake_client = FakeDaprActorClient
+
+        _fake_factory = FakeActoryProxyFactory(_fake_client)
+        _proxy = ActorProxy.create(
+            FakeMultiInterfacesActor.__name__,
+            ActorId('fake-id'),
+            FakeActorCls2Interface,
+            _fake_factory)
+        
+        response = _run(_proxy.invoke('ActionMethodWithoutArg'))
         self.assertEqual(b'"expected_response"', response)
-        self._fake_client.invoke_method.assert_called_once_with(
+        _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
-    async def test_invoke_with_static_typing(self):
-        response = await self._proxy.ActionMethod(b'arg0')
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    def test_invoke_with_static_typing(self):
+        _fake_client = FakeDaprActorClient
+
+        _fake_factory = FakeActoryProxyFactory(_fake_client)
+        _proxy = ActorProxy.create(
+            FakeMultiInterfacesActor.__name__,
+            ActorId('fake-id'),
+            FakeActorCls2Interface,
+            _fake_factory)
+        
+        response = _run((_proxy.ActionMethod(b'arg0')))
         self.assertEqual('expected_response', response)
-        self._fake_client.invoke_method.assert_called_once_with(
+        _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    async def test_invoke_with_static_typing_no_arg(self):
-        response = await self._proxy.ActionMethodWithoutArg()
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    def test_invoke_with_static_typing_no_arg(self):
+        _fake_client = FakeDaprActorClient
+
+        _fake_factory = FakeActoryProxyFactory(_fake_client)
+        _proxy = ActorProxy.create(
+            FakeMultiInterfacesActor.__name__,
+            ActorId('fake-id'),
+            FakeActorCls2Interface,
+            _fake_factory)
+        
+        response = _run(_proxy.ActionMethodWithoutArg())
         self.assertEqual('expected_response', response)
-        self._fake_client.invoke_method.assert_called_once_with(
+        _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
-    async def test_raise_exception_non_existing_method(self):
+    def test_raise_exception_non_existing_method(self):
         with self.assertRaises(AttributeError):
-            await self._proxy.non_existing()
+            _run(self._proxy.non_existing())

--- a/tests/actor/test_client_proxy.py
+++ b/tests/actor/test_client_proxy.py
@@ -14,10 +14,11 @@ from dapr.actor.client.proxy import ActorProxy
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import (
-    FakeDaprActorClient,
     FakeMultiInterfacesActor,
     FakeActorCls2Interface,
 )
+
+from tests.actor.fake_client import FakeDaprActorClient
 
 from tests.actor.utils import (
     _async_mock,
@@ -48,7 +49,7 @@ class ActorProxyTests(unittest.TestCase):
             self._fake_factory)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        'tests.actor.fake_client.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke(self):
         response = _run(self._proxy.invoke('ActionMethod', b'arg0'))
@@ -57,7 +58,7 @@ class ActorProxyTests(unittest.TestCase):
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        'tests.actor.fake_client.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_no_arg(self):
         response = _run(self._proxy.invoke('ActionMethodWithoutArg'))
@@ -66,7 +67,7 @@ class ActorProxyTests(unittest.TestCase):
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        'tests.actor.fake_client.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing(self):
         response = _run(self._proxy.ActionMethod(b'arg0'))
@@ -75,7 +76,7 @@ class ActorProxyTests(unittest.TestCase):
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        'tests.actor.fake_client.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing_no_arg(self):
         response = _run(self._proxy.ActionMethodWithoutArg())

--- a/tests/actor/test_client_proxy.py
+++ b/tests/actor/test_client_proxy.py
@@ -20,17 +20,10 @@ from tests.actor.fake_actor_classes import (
     FakeActorCls2Interface,
 )
 
-def async_mock(*args, **kwargs):
-    m = mock.MagicMock(*args, **kwargs)
-
-    async def mock_coro(*args, **kwargs):
-        return m(*args, **kwargs)
-
-    mock_coro.mock = m
-    return mock_coro
-
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+from tests.actor.utils import (
+    _async_mock,
+    _run
+)
 
 class FakeActoryProxyFactory:
     def __init__(self, fake_client):
@@ -45,7 +38,7 @@ class FakeActoryProxyFactory:
 
 class ActorProxyTests(unittest.TestCase):
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke(self):
         _fake_client = FakeDaprActorClient
 
@@ -61,7 +54,7 @@ class ActorProxyTests(unittest.TestCase):
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_no_arg(self):
         _fake_client = FakeDaprActorClient
 
@@ -77,7 +70,7 @@ class ActorProxyTests(unittest.TestCase):
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing(self):
         _fake_client = FakeDaprActorClient
 
@@ -93,7 +86,7 @@ class ActorProxyTests(unittest.TestCase):
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=async_mock(return_value=b'"expected_response"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing_no_arg(self):
         _fake_client = FakeDaprActorClient
 

--- a/tests/actor/test_client_proxy.py
+++ b/tests/actor/test_client_proxy.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 """
 
 import unittest
-import asyncio
 
 from unittest import mock
 
@@ -25,6 +24,7 @@ from tests.actor.utils import (
     _run
 )
 
+
 class FakeActoryProxyFactory:
     def __init__(self, fake_client):
         # TODO: support serializer for state store later
@@ -38,7 +38,9 @@ class FakeActoryProxyFactory:
 
 class ActorProxyTests(unittest.TestCase):
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke(self):
         _fake_client = FakeDaprActorClient
 
@@ -54,7 +56,9 @@ class ActorProxyTests(unittest.TestCase):
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_no_arg(self):
         _fake_client = FakeDaprActorClient
 
@@ -64,13 +68,15 @@ class ActorProxyTests(unittest.TestCase):
             ActorId('fake-id'),
             FakeActorCls2Interface,
             _fake_factory)
-        
+
         response = _run(_proxy.invoke('ActionMethodWithoutArg'))
         self.assertEqual(b'"expected_response"', response)
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing(self):
         _fake_client = FakeDaprActorClient
 
@@ -80,13 +86,15 @@ class ActorProxyTests(unittest.TestCase):
             ActorId('fake-id'),
             FakeActorCls2Interface,
             _fake_factory)
-        
+
         response = _run((_proxy.ActionMethod(b'arg0')))
         self.assertEqual('expected_response', response)
         _fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method', new=_async_mock(return_value=b'"expected_response"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
+        new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing_no_arg(self):
         _fake_client = FakeDaprActorClient
 
@@ -96,7 +104,7 @@ class ActorProxyTests(unittest.TestCase):
             ActorId('fake-id'),
             FakeActorCls2Interface,
             _fake_factory)
-        
+
         response = _run(_proxy.ActionMethodWithoutArg())
         self.assertEqual('expected_response', response)
         _fake_client.invoke_method.mock.assert_called_once_with(

--- a/tests/actor/test_client_proxy.py
+++ b/tests/actor/test_client_proxy.py
@@ -37,77 +37,50 @@ class FakeActoryProxyFactory:
 
 
 class ActorProxyTests(unittest.TestCase):
+    def setUp(self):
+        # Create mock client
+        self._fake_client = FakeDaprActorClient
+        self._fake_factory = FakeActoryProxyFactory(self._fake_client)
+        self._proxy = ActorProxy.create(
+            FakeMultiInterfacesActor.__name__,
+            ActorId('fake-id'),
+            FakeActorCls2Interface,
+            self._fake_factory)
 
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke(self):
-        _fake_client = FakeDaprActorClient
-
-        _fake_factory = FakeActoryProxyFactory(_fake_client)
-        _proxy = ActorProxy.create(
-            FakeMultiInterfacesActor.__name__,
-            ActorId('fake-id'),
-            FakeActorCls2Interface,
-            _fake_factory)
-
-        response = _run(_proxy.invoke('ActionMethod', b'arg0'))
+        response = _run(self._proxy.invoke('ActionMethod', b'arg0'))
         self.assertEqual(b'"expected_response"', response)
-        _fake_client.invoke_method.mock.assert_called_once_with(
+        self._fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_no_arg(self):
-        _fake_client = FakeDaprActorClient
-
-        _fake_factory = FakeActoryProxyFactory(_fake_client)
-        _proxy = ActorProxy.create(
-            FakeMultiInterfacesActor.__name__,
-            ActorId('fake-id'),
-            FakeActorCls2Interface,
-            _fake_factory)
-
-        response = _run(_proxy.invoke('ActionMethodWithoutArg'))
+        response = _run(self._proxy.invoke('ActionMethodWithoutArg'))
         self.assertEqual(b'"expected_response"', response)
-        _fake_client.invoke_method.mock.assert_called_once_with(
+        self._fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing(self):
-        _fake_client = FakeDaprActorClient
-
-        _fake_factory = FakeActoryProxyFactory(_fake_client)
-        _proxy = ActorProxy.create(
-            FakeMultiInterfacesActor.__name__,
-            ActorId('fake-id'),
-            FakeActorCls2Interface,
-            _fake_factory)
-
-        response = _run((_proxy.ActionMethod(b'arg0')))
+        response = _run(self._proxy.ActionMethod(b'arg0'))
         self.assertEqual('expected_response', response)
-        _fake_client.invoke_method.mock.assert_called_once_with(
+        self._fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethod', b'arg0')
 
     @mock.patch(
         'tests.actor.fake_actor_classes.FakeDaprActorClient.invoke_method',
         new=_async_mock(return_value=b'"expected_response"'))
     def test_invoke_with_static_typing_no_arg(self):
-        _fake_client = FakeDaprActorClient
-
-        _fake_factory = FakeActoryProxyFactory(_fake_client)
-        _proxy = ActorProxy.create(
-            FakeMultiInterfacesActor.__name__,
-            ActorId('fake-id'),
-            FakeActorCls2Interface,
-            _fake_factory)
-
-        response = _run(_proxy.ActionMethodWithoutArg())
+        response = _run(self._proxy.ActionMethodWithoutArg())
         self.assertEqual('expected_response', response)
-        _fake_client.invoke_method.mock.assert_called_once_with(
+        self._fake_client.invoke_method.mock.assert_called_once_with(
             FakeMultiInterfacesActor.__name__, 'fake-id', 'ActionMethodWithoutArg', None)
 
     def test_raise_exception_non_existing_method(self):

--- a/tests/actor/test_method_dispatcher.py
+++ b/tests/actor/test_method_dispatcher.py
@@ -18,9 +18,7 @@ from tests.actor.fake_actor_classes import (
     FakeSimpleActor
 )
 
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
-
+from tests.actor.utils import _run
 
 class ActorMethodDispatcherTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_method_dispatcher.py
+++ b/tests/actor/test_method_dispatcher.py
@@ -6,21 +6,27 @@ Licensed under the MIT License.
 """
 
 import unittest
-from unittest.mock import AsyncMock
+import asyncio
 
 from dapr.actor.runtime.context import ActorRuntimeContext
 from dapr.actor.runtime.method_dispatcher import ActorMethodDispatcher
 from dapr.actor.runtime._type_information import ActorTypeInformation
 from dapr.serializers import DefaultJSONSerializer
 
-from tests.actor.fake_actor_classes import FakeSimpleActor
+from tests.actor.fake_actor_classes import (
+    FakeDaprActorClient,
+    FakeSimpleActor
+)
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 
-class ActorMethodDispatcherTests(unittest.IsolatedAsyncioTestCase):
+class ActorMethodDispatcherTests(unittest.TestCase):
     def setUp(self):
         self._testActorTypeInfo = ActorTypeInformation.create(FakeSimpleActor)
         self._serializer = DefaultJSONSerializer()
-        self._fake_client = AsyncMock()
+        self._fake_client = FakeDaprActorClient
         self._fake_runtime_ctx = ActorRuntimeContext(
             self._testActorTypeInfo, self._serializer,
             self._serializer, self._fake_client)
@@ -40,8 +46,8 @@ class ActorMethodDispatcherTests(unittest.IsolatedAsyncioTestCase):
         arg_names = dispatcher.get_return_type("ActorMethod")
         self.assertEqual(dict, arg_names)
 
-    async def test_dispatch(self):
+    def test_dispatch(self):
         dispatcher = ActorMethodDispatcher(self._testActorTypeInfo)
         actorInstance = FakeSimpleActor(self._fake_runtime_ctx, None)
-        result = await dispatcher.dispatch(actorInstance, "ActorMethod", 10)
+        result = _run(dispatcher.dispatch(actorInstance, "ActorMethod", 10))
         self.assertEqual({'name': 'actor_method'}, result)

--- a/tests/actor/test_method_dispatcher.py
+++ b/tests/actor/test_method_dispatcher.py
@@ -12,11 +12,8 @@ from dapr.actor.runtime.method_dispatcher import ActorMethodDispatcher
 from dapr.actor.runtime._type_information import ActorTypeInformation
 from dapr.serializers import DefaultJSONSerializer
 
-from tests.actor.fake_actor_classes import (
-    FakeDaprActorClient,
-    FakeSimpleActor
-)
-
+from tests.actor.fake_actor_classes import FakeSimpleActor
+from tests.actor.fake_client import FakeDaprActorClient
 from tests.actor.utils import _run
 
 

--- a/tests/actor/test_method_dispatcher.py
+++ b/tests/actor/test_method_dispatcher.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 """
 
 import unittest
-import asyncio
 
 from dapr.actor.runtime.context import ActorRuntimeContext
 from dapr.actor.runtime.method_dispatcher import ActorMethodDispatcher
@@ -19,6 +18,7 @@ from tests.actor.fake_actor_classes import (
 )
 
 from tests.actor.utils import _run
+
 
 class ActorMethodDispatcherTests(unittest.TestCase):
     def setUp(self):

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -18,8 +18,7 @@ from dapr.actor.runtime._type_information import ActorTypeInformation
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import FakeSimpleActor
-
-from tests.actor.fake_actor_classes import FakeDaprActorClient
+from tests.actor.fake_client import FakeDaprActorClient
 
 from tests.actor.utils import (
     _async_mock,
@@ -40,10 +39,10 @@ class ActorStateManagerTests(unittest.TestCase):
         self._fake_actor = FakeSimpleActor(self._runtime_ctx, self._test_actor_id)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=base64.b64encode(b'"value1"')))
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally',
+        'tests.actor.fake_client.FakeDaprActorClient.save_state_transactionally',
         new=_async_mock())
     def test_add_state(self):
 
@@ -61,7 +60,7 @@ class ActorStateManagerTests(unittest.TestCase):
         added = _run(state_manager.try_add_state('state1', 'value1'))
         self.assertFalse(added)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_get_state_for_no_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -76,7 +75,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertIsNone(val)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_existing_value(self):
 
@@ -86,7 +85,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual("value1", val)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_removed_value(self):
 
@@ -101,7 +100,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_set_state_for_new_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -111,7 +110,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value1', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_set_state_for_existing_state_only_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -127,7 +126,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual('value2', state.value)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_set_state_for_existing_state(self):
 
@@ -137,7 +136,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_for_non_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -145,7 +144,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertFalse(removed)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_remove_state_for_existing_state(self):
 
@@ -156,7 +155,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.remove, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -164,7 +163,7 @@ class ActorStateManagerTests(unittest.TestCase):
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_twice_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -174,7 +173,7 @@ class ActorStateManagerTests(unittest.TestCase):
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_contains_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -184,7 +183,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertTrue(exist)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_contains_state_for_existing_state(self):
 
@@ -193,7 +192,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertTrue(exist)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_existing_state(self):
 
@@ -202,7 +201,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual('value1', val)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock())
     def test_get_or_add_state_for_non_existing_state(self):
         state_manager = ActorStateManager(self._fake_actor)
@@ -217,7 +216,7 @@ class ActorStateManagerTests(unittest.TestCase):
             self._test_actor_id.id, 'state1')
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_removed_state(self):
 
@@ -231,7 +230,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_add_or_update_state_for_new_state(self):
         """adds state if state does not exist."""
         def test_update_value(name, value):
@@ -244,7 +243,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_state_in_storage(self):
         """updates state value using update_value_factory if state is
@@ -259,7 +258,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.update, state.change_kind)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_removed_state(self):
         """add state value if state was removed."""
@@ -273,7 +272,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual('value1', val)
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_none_state_key(self):
         """update state value for StateChangeKind.none state """
@@ -294,7 +293,7 @@ class ActorStateManagerTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             _run(state_manager.add_or_update_state('state1', 'value1', None))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_get_state_names(self):
         state_manager = ActorStateManager(self._fake_actor)
         _run(state_manager.set_state('state1', 'value1'))
@@ -317,7 +316,7 @@ class ActorStateManagerTests(unittest.TestCase):
             'state3')
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value0"'))
     def test_clear_cache(self):
         state_manager = ActorStateManager(self._fake_actor)
@@ -329,10 +328,10 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(0, len(state_manager._state_change_tracker))
 
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
         new=_async_mock(return_value=b'"value3"'))
     @mock.patch(
-        'tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally',
+        'tests.actor.fake_client.FakeDaprActorClient.save_state_transactionally',
         new=_async_mock())
     def test_save_state(self):
         state_manager = ActorStateManager(self._fake_actor)

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -21,20 +21,12 @@ from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import FakeSimpleActor
 
-
-def _async_mock(*args, **kwargs):
-    m = mock.MagicMock(*args, **kwargs)
-
-    async def mock_coro(*args, **kwargs):
-        return m(*args, **kwargs)
-
-    mock_coro.mock = m
-    return mock_coro
-
-def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
-
 from tests.actor.fake_actor_classes import FakeDaprActorClient
+
+from tests.actor.utils import (
+    _async_mock,
+    _run
+)
 
 class ActorStateManagerTests(unittest.TestCase):
     def setUp(self):
@@ -48,8 +40,8 @@ class ActorStateManagerTests(unittest.TestCase):
             self._test_type_info, self._serializer, self._serializer, self._fake_client)
         self._fake_actor = FakeSimpleActor(self._runtime_ctx, self._test_actor_id)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=base64.b64encode(b'"value1"')))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=base64.b64encode(b'"value1"')))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=_async_mock())
     def test_add_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -66,7 +58,7 @@ class ActorStateManagerTests(unittest.TestCase):
         added = _run(state_manager.try_add_state('state1', 'value1'))
         self.assertFalse(added)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_get_state_for_no_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -80,7 +72,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_existing_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -88,7 +80,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertTrue(has_value)
         self.assertEqual("value1", val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_removed_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -102,7 +94,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_set_state_for_new_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -112,7 +104,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value1', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_set_state_for_existing_state_only_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -127,7 +119,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_set_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -136,14 +128,14 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_for_non_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_remove_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -153,7 +145,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.remove, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -161,7 +153,7 @@ class ActorStateManagerTests(unittest.TestCase):
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_twice_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -171,7 +163,7 @@ class ActorStateManagerTests(unittest.TestCase):
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_contains_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -180,21 +172,21 @@ class ActorStateManagerTests(unittest.TestCase):
         exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_contains_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
         exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
         val = _run(state_manager.get_or_add_state('state1', 'value2'))
         self.assertEqual('value1', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_get_or_add_state_for_non_existing_state(self):
         state_manager = ActorStateManager(self._fake_actor)
         val = _run(state_manager.get_or_add_state('state1', 'value2'))
@@ -205,7 +197,7 @@ class ActorStateManagerTests(unittest.TestCase):
 
         self._fake_client.get_state.mock.assert_called_once_with(self._test_type_info._name, self._test_actor_id.id, 'state1')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -218,7 +210,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_add_or_update_state_for_new_state(self):
         """adds state if state does not exist."""
         def test_update_value(name, value):
@@ -230,7 +222,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_state_in_storage(self):
         """updates state value using update_value_factory if state is
         in the storage."""
@@ -243,7 +235,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_removed_state(self):
         """add state value if state was removed."""
         def test_update_value(name, value):
@@ -255,7 +247,7 @@ class ActorStateManagerTests(unittest.TestCase):
         val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('value1', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_none_state_key(self):
         """update state value for StateChangeKind.none state """
         def test_update_value(name, value):
@@ -275,7 +267,7 @@ class ActorStateManagerTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             _run(state_manager.add_or_update_state('state1', 'value1', None))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
     def test_get_state_names(self):
         state_manager = ActorStateManager(self._fake_actor)
         _run(state_manager.set_state('state1', 'value1'))
@@ -288,7 +280,7 @@ class ActorStateManagerTests(unittest.TestCase):
         self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state2')
         self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state3')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value0"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value0"'))
     def test_clear_cache(self):
         state_manager = ActorStateManager(self._fake_actor)
         _run(state_manager.set_state('state1', 'value1'))
@@ -298,8 +290,8 @@ class ActorStateManagerTests(unittest.TestCase):
 
         self.assertEqual(0, len(state_manager._state_change_tracker))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value3"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=async_mock())
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value3"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=_async_mock())
     def test_save_state(self):
         state_manager = ActorStateManager(self._fake_actor)
         # set states which are StateChangeKind.add

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -7,8 +7,9 @@ Licensed under the MIT License.
 
 import base64
 import unittest
+import asyncio
 
-from unittest.mock import AsyncMock
+from unittest import mock
 
 from dapr.actor.id import ActorId
 from dapr.actor.runtime.context import ActorRuntimeContext
@@ -21,10 +22,24 @@ from dapr.serializers import DefaultJSONSerializer
 from tests.actor.fake_actor_classes import FakeSimpleActor
 
 
-class ActorStateManagerTests(unittest.IsolatedAsyncioTestCase):
+def _async_mock(*args, **kwargs):
+    m = mock.MagicMock(*args, **kwargs)
+
+    async def mock_coro(*args, **kwargs):
+        return m(*args, **kwargs)
+
+    mock_coro.mock = m
+    return mock_coro
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+from tests.actor.fake_actor_classes import FakeDaprActorClient
+
+class ActorStateManagerTests(unittest.TestCase):
     def setUp(self):
         # Create mock client
-        self._fake_client = AsyncMock(DaprActorClientBase)
+        self._fake_client = FakeDaprActorClient
 
         self._test_actor_id = ActorId('1')
         self._test_type_info = ActorTypeInformation.create(FakeSimpleActor)
@@ -33,14 +48,14 @@ class ActorStateManagerTests(unittest.IsolatedAsyncioTestCase):
             self._test_type_info, self._serializer, self._serializer, self._fake_client)
         self._fake_actor = FakeSimpleActor(self._runtime_ctx, self._test_actor_id)
 
-    async def test_add_state(self):
-        self._fake_client.get_state.return_value = base64.b64encode(b'"value1"')
-        self._fake_client.save_state_transactionally.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=base64.b64encode(b'"value1"')))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=async_mock())
+    def test_add_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
 
         # Add first 'state1'
-        added = await state_manager.try_add_state('state1', 'value1')
+        added = _run(state_manager.try_add_state('state1', 'value1'))
         self.assertTrue(added)
 
         state = state_manager._state_change_tracker['state1']
@@ -48,260 +63,264 @@ class ActorStateManagerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
         # Add 'state1' again
-        added = await state_manager.try_add_state('state1', 'value1')
+        added = _run(state_manager.try_add_state('state1', 'value1'))
         self.assertFalse(added)
 
-    async def test_get_state_for_no_state(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_get_state_for_no_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        has_value, val = await state_manager.try_get_state('state1')
+        has_value, val = _run(state_manager.try_get_state('state1'))
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
         # Test if the test value is empty string
         self._fake_client.get_state.return_value = ''
-        has_value, val = await state_manager.try_get_state('state1')
+        has_value, val = _run(state_manager.try_get_state('state1'))
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    async def test_get_state_for_existing_value(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_get_state_for_existing_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        has_value, val = await state_manager.try_get_state('state1')
+        has_value, val = _run(state_manager.try_get_state('state1'))
         self.assertTrue(has_value)
         self.assertEqual("value1", val)
 
-    async def test_get_state_for_removed_value(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_get_state_for_removed_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        removed = await state_manager.try_remove_state('state1')
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
 
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.remove, state.change_kind)
 
-        has_value, val = await state_manager.try_get_state('state1')
+        has_value, val = _run(state_manager.try_get_state('state1'))
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    async def test_set_state_for_new_state(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_set_state_for_new_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
+        _run(state_manager.set_state('state1', 'value1'))
 
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value1', state.value)
 
-    async def test_set_state_for_existing_state_only_in_mem(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_set_state_for_existing_state_only_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
+        _run(state_manager.set_state('state1', 'value1'))
 
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value1', state.value)
 
-        await state_manager.set_state('state1', 'value2')
+        _run(state_manager.set_state('state1', 'value2'))
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    async def test_set_state_for_existing_state(self):
-        # Test if the test value is None
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_set_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value2')
+        _run(state_manager.set_state('state1', 'value2'))
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    async def test_remove_state_for_non_existing_state(self):
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_remove_state_for_non_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        removed = await state_manager.try_remove_state('state1')
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    async def test_remove_state_for_existing_state(self):
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_remove_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        removed = await state_manager.try_remove_state('state1')
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
 
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.remove, state.change_kind)
 
-    async def test_remove_state_for_existing_state_in_mem(self):
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_remove_state_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
-        removed = await state_manager.try_remove_state('state1')
+        _run(state_manager.set_state('state1', 'value1'))
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
 
-    async def test_remove_state_twice_for_existing_state_in_mem(self):
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_remove_state_twice_for_existing_state_in_mem(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
-        removed = await state_manager.try_remove_state('state1')
+        _run(state_manager.set_state('state1', 'value1'))
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertTrue(removed)
-        removed = await state_manager.try_remove_state('state1')
+        removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    async def test_contains_state_for_removed_state(self):
-        self._fake_client.get_state.return_value = None
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_contains_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
+        _run(state_manager.set_state('state1', 'value1'))
 
-        exist = await state_manager.contains_state('state1')
+        exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    async def test_contains_state_for_existing_state(self):
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_contains_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        exist = await state_manager.contains_state('state1')
+        exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    async def test_get_or_add_state_for_existing_state(self):
-        self._fake_client.get_state.return_value = b'"value1"'
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_get_or_add_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        val = await state_manager.get_or_add_state('state1', 'value2')
+        val = _run(state_manager.get_or_add_state('state1', 'value2'))
         self.assertEqual('value1', val)
 
-    async def test_get_or_add_state_for_non_existing_state(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_get_or_add_state_for_non_existing_state(self):
         state_manager = ActorStateManager(self._fake_actor)
-        val = await state_manager.get_or_add_state('state1', 'value2')
+        val = _run(state_manager.get_or_add_state('state1', 'value2'))
 
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', val)
 
-    async def test_get_or_add_state_for_removed_state(self):
-        self._fake_client.get_state.return_value = b'"value1"'
+        self._fake_client.get_state.mock.assert_called_once_with(self._test_type_info._name, self._test_actor_id.id, 'state1')
+
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_get_or_add_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.remove_state('state1')
+        _run(state_manager.remove_state('state1'))
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.remove, state.change_kind)
 
-        val = await state_manager.get_or_add_state('state1', 'value2')
+        val = _run(state_manager.get_or_add_state('state1', 'value2'))
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', val)
 
-    async def test_add_or_update_state_for_new_state(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_add_or_update_state_for_new_state(self):
         """adds state if state does not exist."""
         def test_update_value(name, value):
             return f'{name}-{value}'
 
         state_manager = ActorStateManager(self._fake_actor)
-        val = await state_manager.add_or_update_state('state1', 'value1', test_update_value)
+        val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('value1', val)
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
-    async def test_add_or_update_state_for_state_in_storage(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_add_or_update_state_for_state_in_storage(self):
         """updates state value using update_value_factory if state is
         in the storage."""
         def test_update_value(name, value):
             return f'{name}-{value}'
 
-        self._fake_client.get_state.return_value = b'"value1"'
-
         state_manager = ActorStateManager(self._fake_actor)
-        val = await state_manager.add_or_update_state('state1', 'value1', test_update_value)
+        val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('state1-value1', val)
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
 
-    async def test_add_or_update_state_for_removed_state(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_add_or_update_state_for_removed_state(self):
         """add state value if state was removed."""
         def test_update_value(name, value):
             return f'{name}-{value}'
 
-        self._fake_client.get_state.return_value = b'"value1"'
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.remove_state('state1')
+        _run(state_manager.remove_state('state1'))
 
-        val = await state_manager.add_or_update_state('state1', 'value1', test_update_value)
+        val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('value1', val)
 
-    async def test_add_or_update_state_for_none_state_key(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value1"'))
+    def test_add_or_update_state_for_none_state_key(self):
         """update state value for StateChangeKind.none state """
         def test_update_value(name, value):
             return f'{name}-{value}'
 
-        self._fake_client.get_state.return_value = b'"value1"'
         state_manager = ActorStateManager(self._fake_actor)
-        has_value, val = await state_manager.try_get_state('state1')
+        has_value, val = _run(state_manager.try_get_state('state1'))
         self.assertTrue(has_value)
         self.assertEqual('value1', val)
 
-        val = await state_manager.add_or_update_state('state1', 'value1', test_update_value)
+        val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('state1-value1', val)
 
-    async def test_add_or_update_state_without_update_value_factory(self):
+    def test_add_or_update_state_without_update_value_factory(self):
         """tries to add or update state without update_value_factory """
         state_manager = ActorStateManager(self._fake_actor)
         with self.assertRaises(AttributeError):
-            await state_manager.add_or_update_state('state1', 'value1', None)
+            _run(state_manager.add_or_update_state('state1', 'value1', None))
 
-    async def test_get_state_names(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock())
+    def test_get_state_names(self):
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
-        await state_manager.set_state('state2', 'value2')
-        await state_manager.set_state('state3', 'value3')
-        names = await state_manager.get_state_names()
+        _run(state_manager.set_state('state1', 'value1'))
+        _run(state_manager.set_state('state2', 'value2'))
+        _run(state_manager.set_state('state3', 'value3'))
+        names = _run(state_manager.get_state_names())
         self.assertEqual(['state1', 'state2', 'state3'], names)
 
-    async def test_clear_cache(self):
+        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state1')
+        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state2')
+        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state3')
+
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value0"'))
+    def test_clear_cache(self):
         state_manager = ActorStateManager(self._fake_actor)
-        await state_manager.set_state('state1', 'value1')
-        await state_manager.set_state('state2', 'value2')
-        await state_manager.set_state('state3', 'value3')
-        await state_manager.clear_cache()
+        _run(state_manager.set_state('state1', 'value1'))
+        _run(state_manager.set_state('state2', 'value2'))
+        _run(state_manager.set_state('state3', 'value3'))
+        _run(state_manager.clear_cache())
 
         self.assertEqual(0, len(state_manager._state_change_tracker))
 
-    async def test_save_state(self):
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=async_mock(return_value=b'"value3"'))
+    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=async_mock())
+    def test_save_state(self):
         state_manager = ActorStateManager(self._fake_actor)
         # set states which are StateChangeKind.add
-        await state_manager.set_state('state1', 'value1')
-        await state_manager.set_state('state2', 'value2')
-        # set state which is StateChangeKind.none
-        self._fake_client.get_state.return_value = b'"value3"'
-        has_value, val = await state_manager.try_get_state('state3')
+        _run(state_manager.set_state('state1', 'value1'))
+        _run(state_manager.set_state('state2', 'value2'))
+
+        has_value, val = _run(state_manager.try_get_state('state3'))
         self.assertTrue(has_value)
         self.assertEqual("value3", val)
         # set state which is StateChangeKind.remove
-        await state_manager.remove_state('state4')
+        _run(state_manager.remove_state('state4'))
         # set state which is StateChangeKind.update
-        await state_manager.set_state('state5', 'value5')
+        _run(state_manager.set_state('state5', 'value5'))
         expected = b'[{"operation":"upsert","request":{"key":"state1","value":"value1"}},{"operation":"upsert","request":{"key":"state2","value":"value2"}},{"operation":"delete","request":{"key":"state4"}},{"operation":"upsert","request":{"key":"state5","value":"value5"}}]'  # noqa: E501
 
         # Save the state
-        async def mock_save_state(actor_type, actor_id, data):
+        def mock_save_state(actor_type, actor_id, data):
             self.assertEqual(expected, data)
 
-        self._fake_client.save_state_transactionally = mock_save_state
-        await state_manager.save_state()
+        self._fake_client.save_state_transactionally.mock = mock_save_state
+        _run(state_manager.save_state())
 
 
 if __name__ == '__main__':

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -7,7 +7,6 @@ Licensed under the MIT License.
 
 import base64
 import unittest
-import asyncio
 
 from unittest import mock
 
@@ -16,7 +15,6 @@ from dapr.actor.runtime.context import ActorRuntimeContext
 from dapr.actor.runtime.state_change import StateChangeKind
 from dapr.actor.runtime.state_manager import ActorStateManager
 from dapr.actor.runtime._type_information import ActorTypeInformation
-from dapr.clients.base import DaprActorClientBase
 from dapr.serializers import DefaultJSONSerializer
 
 from tests.actor.fake_actor_classes import FakeSimpleActor
@@ -27,6 +25,7 @@ from tests.actor.utils import (
     _async_mock,
     _run
 )
+
 
 class ActorStateManagerTests(unittest.TestCase):
     def setUp(self):
@@ -40,8 +39,12 @@ class ActorStateManagerTests(unittest.TestCase):
             self._test_type_info, self._serializer, self._serializer, self._fake_client)
         self._fake_actor = FakeSimpleActor(self._runtime_ctx, self._test_actor_id)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=base64.b64encode(b'"value1"')))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=_async_mock())
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=base64.b64encode(b'"value1"')))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally',
+        new=_async_mock())
     def test_add_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -72,7 +75,9 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertFalse(has_value)
         self.assertIsNone(val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_existing_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -80,7 +85,9 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertTrue(has_value)
         self.assertEqual("value1", val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_get_state_for_removed_value(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -119,7 +126,9 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', state.value)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_set_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -135,7 +144,9 @@ class ActorStateManagerTests(unittest.TestCase):
         removed = _run(state_manager.try_remove_state('state1'))
         self.assertFalse(removed)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_remove_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -172,21 +183,27 @@ class ActorStateManagerTests(unittest.TestCase):
         exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_contains_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
         exist = _run(state_manager.contains_state('state1'))
         self.assertTrue(exist)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_existing_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
         val = _run(state_manager.get_or_add_state('state1', 'value2'))
         self.assertEqual('value1', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock())
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock())
     def test_get_or_add_state_for_non_existing_state(self):
         state_manager = ActorStateManager(self._fake_actor)
         val = _run(state_manager.get_or_add_state('state1', 'value2'))
@@ -195,9 +212,13 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', val)
 
-        self._fake_client.get_state.mock.assert_called_once_with(self._test_type_info._name, self._test_actor_id.id, 'state1')
+        self._fake_client.get_state.mock.assert_called_once_with(
+            self._test_type_info._name,
+            self._test_actor_id.id, 'state1')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_get_or_add_state_for_removed_state(self):
 
         state_manager = ActorStateManager(self._fake_actor)
@@ -222,7 +243,9 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_state_in_storage(self):
         """updates state value using update_value_factory if state is
         in the storage."""
@@ -235,7 +258,9 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_manager._state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_removed_state(self):
         """add state value if state was removed."""
         def test_update_value(name, value):
@@ -247,7 +272,9 @@ class ActorStateManagerTests(unittest.TestCase):
         val = _run(state_manager.add_or_update_state('state1', 'value1', test_update_value))
         self.assertEqual('value1', val)
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value1"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'))
     def test_add_or_update_state_for_none_state_key(self):
         """update state value for StateChangeKind.none state """
         def test_update_value(name, value):
@@ -276,11 +303,22 @@ class ActorStateManagerTests(unittest.TestCase):
         names = _run(state_manager.get_state_names())
         self.assertEqual(['state1', 'state2', 'state3'], names)
 
-        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state1')
-        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state2')
-        self._fake_client.get_state.mock.assert_any_call(self._test_type_info._name, self._test_actor_id.id, 'state3')
+        self._fake_client.get_state.mock.assert_any_call(
+            self._test_type_info._name,
+            self._test_actor_id.id,
+            'state1')
+        self._fake_client.get_state.mock.assert_any_call(
+            self._test_type_info._name,
+            self._test_actor_id.id,
+            'state2')
+        self._fake_client.get_state.mock.assert_any_call(
+            self._test_type_info._name,
+            self._test_actor_id.id,
+            'state3')
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value0"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value0"'))
     def test_clear_cache(self):
         state_manager = ActorStateManager(self._fake_actor)
         _run(state_manager.set_state('state1', 'value1'))
@@ -290,8 +328,12 @@ class ActorStateManagerTests(unittest.TestCase):
 
         self.assertEqual(0, len(state_manager._state_change_tracker))
 
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.get_state', new=_async_mock(return_value=b'"value3"'))
-    @mock.patch('tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally', new=_async_mock())
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value3"'))
+    @mock.patch(
+        'tests.actor.fake_actor_classes.FakeDaprActorClient.save_state_transactionally',
+        new=_async_mock())
     def test_save_state(self):
         state_manager = ActorStateManager(self._fake_actor)
         # set states which are StateChangeKind.add

--- a/tests/actor/utils.py
+++ b/tests/actor/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest import mock
 
+
 def _async_mock(*args, **kwargs):
     m = mock.MagicMock(*args, **kwargs)
 
@@ -9,6 +10,7 @@ def _async_mock(*args, **kwargs):
 
     mock_coro.mock = m
     return mock_coro
+
 
 def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)

--- a/tests/actor/utils.py
+++ b/tests/actor/utils.py
@@ -1,0 +1,14 @@
+import asyncio
+from unittest import mock
+
+def _async_mock(*args, **kwargs):
+    m = mock.MagicMock(*args, **kwargs)
+
+    async def mock_coro(*args, **kwargs):
+        return m(*args, **kwargs)
+
+    mock_coro.mock = m
+    return mock_coro
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 minversion = 3.8.0
 envlist =
-    py38,
+    py37,
     flake8,
     mypy,
 
@@ -15,21 +15,21 @@ commands =
     python3 -m unittest discover -v ./tests
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3.7
 usedevelop = False
 deps = flake8
 commands =
     flake8 .
 
 [testenv:type]
-basepython = python3.8
+basepython = python3.7
 usedevelop = False
 deps = -rdev-requirements.txt
 commands =
     mypy --config-file mypy.ini
 
 [testenv:doc]
-basepython = python3.8
+basepython = python3.7
 usedevelop = False
 whitelist_externals = make
 deps = sphinx


### PR DESCRIPTION
# Description

Made changes to support using python-sdk with Python 3.7

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #82 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
