### PR TITLE
Upgrade protobuf

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,10 +4,9 @@ mypy-extensions>=0.4.3
 flake8>=3.7.9 
 aiohttp>=3.6.2
 python-dateutil>=2.8.1
-protobuf == 3.11.3
 grpcio==1.26.0
 grpcio-tools==1.26.0
-protobuf==3.11.3
+protobuf==3.13.0
 six==1.14.0
 tox == 3.15.0
 cloudevents >= 0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 3.11.3
+    protobuf == 3.13.0
     grpcio == 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1


### PR DESCRIPTION
# Description

Upgrades protobuf version to be compatible with google-api-core 1.22.4

$ pip3 check
google-api-core 1.22.4 has requirement protobuf>=3.12.0, but you have protobuf 3.11.3.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close:

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
