### PR TITLE
Use cumulative coverage data

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,4 @@ coverage:
 
 ignore:
   - dapr/proto # - Generated GRPC client
+  - tests      # - tests

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ setenv =
 deps = -rdev-requirements.txt
 commands =
     coverage run -m unittest discover -v ./tests
-    coverage run -m unittest discover -v ./ext/dapr-ext-grpc/tests
-    coverage run -m unittest discover -v ./ext/dapr-ext-fastapi/tests
+    coverage run -a -m unittest discover -v ./ext/dapr-ext-grpc/tests
+    coverage run -a -m unittest discover -v ./ext/dapr-ext-fastapi/tests
     coverage xml
 commands_pre =
     pip3 install -e {toxinidir}/


### PR DESCRIPTION
# Description

When generating coverage data with multiple tests runs, you need to use -a or the coverage data will be overwritten by the subsequent runs.


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
