### PR TITLE
Stateless actor timer invocation.

### DIFF
--- a/dapr/actor/runtime/_timer_data.py
+++ b/dapr/actor/runtime/_timer_data.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 from datetime import timedelta
 from typing import Any, Awaitable, Callable, Dict
 
-# TIMER_CALLBACK is the type hint for timer callback.
 TIMER_CALLBACK = Callable[[Any], Awaitable[None]]
 
 
@@ -40,7 +39,7 @@ class ActorTimerData:
                 invocations after the first timer trigger.
         """
         self._name = name
-        self._callback = callback
+        self._callback = callback.__name__
         self._state = state
         self._due_time = due_time
         self._period = period
@@ -66,7 +65,7 @@ class ActorTimerData:
         return self._period
 
     @property
-    def callback(self) -> TIMER_CALLBACK:
+    def callback(self) -> str:
         """Gets the callback of the actor timer."""
         return self._callback
 
@@ -77,6 +76,8 @@ class ActorTimerData:
         """
 
         return {
+            'callback': self._callback,
+            'data': self._state,
             'dueTime': self._due_time,
             'period': self._period,
         }

--- a/dapr/actor/runtime/manager.py
+++ b/dapr/actor/runtime/manager.py
@@ -70,9 +70,13 @@ class ActorManager:
 
         await self._dispatch_internal(actor_id, self._reminder_method_context, invoke_reminder)
 
-    async def fire_timer(self, actor_id: ActorId, timer_name: str) -> None:
+    async def fire_timer(
+            self, actor_id: ActorId,
+            timer_name: str, request_body: bytes) -> None:
+        timer = self._message_serializer.deserialize(request_body, object)
+
         async def invoke_timer(actor: Actor) -> Optional[bytes]:
-            await actor._fire_timer_internal(timer_name)
+            await actor._fire_timer_internal(timer['callback'], timer['data'])
             return None
 
         await self._dispatch_internal(actor_id, self._reminder_method_context, invoke_timer)

--- a/dapr/actor/runtime/runtime.py
+++ b/dapr/actor/runtime/runtime.py
@@ -99,14 +99,14 @@ class ActorRuntime:
     @classmethod
     async def fire_reminder(
             cls, actor_type_name: str, actor_id: str,
-            name: str, request_body: bytes) -> None:
+            name: str, state: bytes) -> None:
         """Fires a reminder for the Actor.
 
         Args:
             actor_type_name (str): the name of actor type.
             actor_id (str): Actor ID.
             name (str): the name of reminder.
-            request_body (bytes): the body of request that is passed to reminder callback.
+            state (bytes): the body of request that is passed to reminder callback.
 
         Raises:
             ValueError: `actor_type_name` actor type is not registered.
@@ -115,16 +115,20 @@ class ActorRuntime:
         manager = await cls._get_actor_manager(actor_type_name)
         if not manager:
             raise ValueError(f'{actor_type_name} is not registered.')
-        await manager.fire_reminder(ActorId(actor_id), name, request_body)
+        await manager.fire_reminder(ActorId(actor_id), name, state)
 
     @classmethod
-    async def fire_timer(cls, actor_type_name: str, actor_id: str, name: str) -> None:
+    async def fire_timer(
+            cls, actor_type_name: str,
+            actor_id: str, name: str,
+            state: bytes) -> None:
         """Fires a timer for the Actor.
 
         Args:
             actor_type_name (str): the name of actor type.
             actor_id (str): Actor ID.
-            name (str): the timer name.
+            name (str): the timer's name.
+            state (bytes): the timer's trigger body.
 
         Raises:
             ValueError: `actor_type_name` actor type is not registered.
@@ -132,7 +136,7 @@ class ActorRuntime:
         manager = await cls._get_actor_manager(actor_type_name)
         if not manager:
             raise ValueError(f'{actor_type_name} is not registered.')
-        await manager.fire_timer(ActorId(actor_id), name)
+        await manager.fire_timer(ActorId(actor_id), name, state)
 
     @classmethod
     def set_actor_config(cls, config: ActorRuntimeConfig) -> None:

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
@@ -98,9 +98,15 @@ class DaprActor(object):
             return _wrap_response(status.HTTP_200_OK, result)
 
         @router.put('/actors/{actor_type_name}/{actor_id}/method/timer/{timer_name}')
-        async def actor_timer(actor_type_name: str, actor_id: str, timer_name: str):
+        async def actor_timer(
+                actor_type_name: str,
+                actor_id: str,
+                timer_name: str,
+                request: Request):
             try:
-                await ActorRuntime.fire_timer(actor_type_name, actor_id, timer_name)
+                # Read raw bytes from request stream
+                req_body = await request.body()
+                await ActorRuntime.fire_timer(actor_type_name, actor_id, timer_name, req_body)
             except DaprInternalError as ex:
                 return _wrap_response(
                     status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/ext/flask_dapr/flask_dapr/actor.py
+++ b/ext/flask_dapr/flask_dapr/actor.py
@@ -100,7 +100,9 @@ class DaprActor(object):
 
     def _timer_handler(self, actor_type_name, actor_id, timer_name):
         try:
-            asyncio.run(ActorRuntime.fire_timer(actor_type_name, actor_id, timer_name))
+            # Read raw bytes from request stream
+            req_body = request.stream.read()
+            asyncio.run(ActorRuntime.fire_timer(actor_type_name, actor_id, timer_name, req_body))
         except DaprInternalError as ex:
             return wrap_response(500, ex.as_dict())
         except Exception as ex:

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -151,23 +151,19 @@ class ActorTests(unittest.TestCase):
         # register timer
         _run(test_actor.register_timer(
             'test_timer', test_actor.timer_callback,
-            "timer call", timedelta(seconds=1), timedelta(seconds=1)))
+            "mydata", timedelta(seconds=1), timedelta(seconds=2)))
         test_client.register_timer.mock.assert_called_once()
         test_client.register_timer.mock.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer',
-            b'{"dueTime":"0h0m1s","period":"0h0m1s"}')
-        self.assertTrue('test_timer' in test_actor._timers)
-        self.assertEqual(1, len(test_actor._timers))
+            b'{"callback":"timer_callback","data":"mydata","dueTime":"0h0m1s","period":"0h0m2s"}')
 
         # unregister timer
         _run(test_actor.unregister_timer('test_timer'))
         test_client.unregister_timer.mock.assert_called_once()
         test_client.unregister_timer.mock.assert_called_with(
             'FakeSimpleTimerActor', 'test_id', 'test_timer')
-        self.assertEqual(0, len(test_actor._timers))
 
         # register timer without timer name
         _run(test_actor.register_timer(
             None, test_actor.timer_callback,
             "timer call", timedelta(seconds=1), timedelta(seconds=1)))
-        self.assertEqual("test_id_Timer_1", list(test_actor._timers)[0])

--- a/tests/actor/test_actor_manager.py
+++ b/tests/actor/test_actor_manager.py
@@ -139,6 +139,9 @@ class ActorManagerTimerTests(unittest.TestCase):
             "timer call", timedelta(seconds=1), timedelta(seconds=1)))
 
         # Fire timer
-        _run(manager.fire_timer(test_actor_id, 'test_timer'))
+        _run(manager.fire_timer(
+            test_actor_id,
+            'test_timer',
+            '{ "callback": "timer_callback", "data": "timer call" }'.encode('UTF8')))
 
         self.assertTrue(actor.timer_called)

--- a/tests/actor/test_timer_data.py
+++ b/tests/actor/test_timer_data.py
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
+from typing import Any
 import unittest
 from datetime import timedelta
 
@@ -13,21 +14,26 @@ from dapr.actor.runtime._timer_data import ActorTimerData
 
 class ActorTimerDataTests(unittest.TestCase):
     def test_timer_data(self):
-        def test_callback(obj):
-            self.assertEqual('called', obj)
+        def my_callback(input: Any):
+            print(input)
         timer = ActorTimerData(
-            'timer_name', test_callback, 'called',
-            timedelta(seconds=1), timedelta(seconds=1))
-        self.assertEqual(test_callback, timer.callback)
-        timer.callback('called')
+            'timer_name', my_callback, 'called',
+            timedelta(seconds=2), timedelta(seconds=1))
+        self.assertEqual('timer_name', timer.name)
+        self.assertEqual('my_callback', timer.callback)
+        self.assertEqual('called', timer.state)
+        self.assertEqual(timedelta(seconds=2), timer.due_time)
+        self.assertEqual(timedelta(seconds=1), timer.period)
 
     def test_as_dict(self):
-        def test_callback(obj):
-            self.assertEqual('called', obj)
+        def my_callback(input: Any):
+            print(input)
         timer = ActorTimerData(
-            'timer_name', test_callback, 'called',
+            'timer_name', my_callback, 'called',
             timedelta(seconds=1), timedelta(seconds=1))
         expected = {
+            'callback': 'my_callback',
+            'data': 'called',
             'dueTime': timedelta(seconds=1),
             'period': timedelta(seconds=1),
         }


### PR DESCRIPTION
# Description

Stateless actor timer invocation.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #134 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation


Validated using example and adding a debug message to confirm it was the new code being executed on triggering timer (`FIRE NEW VERSION!!!!`):
```
== APP == INFO:     127.0.0.1:63846 - "PUT /actors/DemoActor/d7627040-27b8-4f73-9394-6075ca406d95/method/remind/myremind HTTP/1.1" 200 OK

== APP == FIRE NEW VERSION!!!!

== APP == time_callback is called - timer_state

== APP == INFO:     127.0.0.1:63846 - "PUT /actors/DemoActor/1/method/timer/demo_timer HTTP/1.1" 200 OK

== APP == FIRE NEW VERSION!!!!

== APP == time_callback is called - timer_state

== APP == INFO:     127.0.0.1:63846 - "PUT /actors/DemoActor/1/method/timer/demo_timer HTTP/1.1" 200 OK

== APP == INFO:     127.0.0.1:63857 - "GET /healthz HTTP/1.1" 200 OK
```



