### PR TITLE
Allows for a more recent version of grpcio

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,8 +4,8 @@ mypy-extensions>=0.4.3
 flake8>=3.7.9 
 aiohttp>=3.6.2
 python-dateutil>=2.8.1
-grpcio==1.26.0
-grpcio-tools==1.26.0
+grpcio>=1.26.0
+grpcio-tools>=1.26.0
 protobuf==3.13.0
 six==1.14.0
 tox == 3.15.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
     protobuf == 3.13.0
-    grpcio == 1.26.0
+    grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1
     opencensus == 0.7.10


### PR DESCRIPTION
# Description

Does not lock to version 1.26.0 of the grpcio library, but allows for a more recent version.

## Issue reference

This issue will close #160 
