### PR TITLE
wait() method so client can wait for sidecar.

### DIFF
--- a/examples/state_store/state_store.py
+++ b/examples/state_store/state_store.py
@@ -21,6 +21,9 @@ with DaprClient() as d:
     yet_another_key = "key_3"
     yet_another_value = "value_3"
 
+    # Wait for sidecar to be up within 5 seconds.
+    d.wait(5)
+
     # Save single state.
     d.save_state(store_name=storeName, key=key, value=value)
     print(f"State store has successfully saved {value} with {key} as key")

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 """
 
+import socket
 import unittest
 import uuid
 
@@ -308,6 +309,21 @@ class DaprGrpcClientTests(unittest.TestCase):
         self.assertEqual(1, len(resp.headers))
         self.assertEqual([key1], resp.headers['keyh'])
         self.assertEqual({key1: "val"}, resp._secret)
+
+    def test_wait_ok(self):
+        dapr = DaprClient(f'localhost:{self.server_port}')
+        dapr.wait(0.1)
+
+    def test_wait_timeout(self):
+        # First, pick an unused port
+        port = 0
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('', 0))
+            port = s.getsockname()[1]
+        dapr = DaprClient(f'localhost:{port}')
+        with self.assertRaises(Exception) as context:
+            dapr.wait(0.1)
+        self.assertTrue('Connection refused' in str(context.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

wait() method so client can wait for sidecar.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #140 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
