### PR TITLE
Update dev container with Dapr CLI and correct requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update \
     # && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
     # && rm -rf /tmp/pip-tmp \
     #
+    # Install Dapr CLI
+    && wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash \
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
 	],
 
-	"postCreateCommand": "pip install -r ./tests/requirements.txt",
+	"postCreateCommand": "pip install -r .dev-requirements.txt",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
 	],
 
-	"postCreateCommand": "pip install -r .dev-requirements.txt",
+	"postCreateCommand": "pip install -r ./dev-requirements.txt",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"ms-azuretools.vscode-dapr"
 	],
 	
 	"mounts": [ 


### PR DESCRIPTION
# Description

This PR enables developers to use this dev container, in both VSCode and GitHUb codespaces, to develop with Dapr in addition to develop on Dapr.

Specifically, it adds the Dapr CLI to the image build and fixes the post-create command of installing all dependencies
