### PR TITLE
Add python-sdk support for publisher cloudevent content_type

### DIFF
--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -289,7 +289,8 @@ class DaprGrpcClient:
             pubsub_name: str,
             topic_name: str,
             data: Union[bytes, str],
-            metadata: Optional[MetadataTuple] = ()) -> DaprResponse:
+            metadata: Optional[MetadataTuple] = (),
+            data_content_type: Optional[str] = None) -> DaprResponse:
         """Publish to a given topic.
         This publishes an event with bytes array or str data to a specified topic and
         specified pubsub component. The str data is encoded into bytes with default
@@ -315,6 +316,7 @@ class DaprGrpcClient:
             topic_name (str): the topic name to publish to
             data (bytes or str): bytes or str for data
             metadata (tuple, optional): custom metadata
+            data_content_type: (str, optional): content type of the data payload
 
         Returns:
             :class:`DaprResponse` gRPC metadata returned from callee
@@ -329,7 +331,8 @@ class DaprGrpcClient:
         req = api_v1.PublishEventRequest(
             pubsub_name=pubsub_name,
             topic=topic_name,
-            data=req_data)
+            data=req_data,
+            data_content_type=data_content_type)
 
         # response is google.protobuf.Empty
         _, call = self._stub.PublishEvent.with_call(req, metadata=metadata)

--- a/examples/pubsub-simple/README.md
+++ b/examples/pubsub-simple/README.md
@@ -26,11 +26,11 @@ Run the following command in a terminal/command prompt:
 <!-- STEP
 name: Run subscriber
 expected_stdout_lines:
-  - '== APP == Subscriber received: id=1, message="hello world"'
-  - '== APP == Subscriber received: id=2, message="hello world"'
-  - '== APP == Subscriber received: id=3, message="hello world"'
-  - '== APP == Subscriber received: id=4, message="hello world"'
-  - '== APP == Subscriber received: id=5, message="hello world"'
+  - '== APP == Subscriber received: id=1, message="hello world", content_type="application/json"'
+  - '== APP == Subscriber received: id=2, message="hello world", content_type="application/json"'
+  - '== APP == Subscriber received: id=3, message="hello world", content_type="application/json"'
+  - '== APP == Subscriber received: id=4, message="hello world", content_type="application/json"'
+  - '== APP == Subscriber received: id=5, message="hello world", content_type="application/json"'
 background: true
 sleep: 5 
 -->
@@ -58,7 +58,7 @@ sleep: 15
 
 ```bash
 # 2. Start Publisher
-dapr run --app-id python-publisher --app-protocol grpc python3 publisher.py
+dapr run --app-id python-publisher --app-protocol grpc --dapr-grpc-port=3500 python3 publisher.py
 ```
 
 <!-- END_STEP -->

--- a/examples/pubsub-simple/publisher.py
+++ b/examples/pubsub-simple/publisher.py
@@ -22,6 +22,7 @@ with DaprClient() as d:
             pubsub_name='pubsub',
             topic_name='TOPIC_A',
             data=json.dumps(req_data),
+            data_content_type='application/json',
         )
 
         # Print the request

--- a/examples/pubsub-simple/subscriber.py
+++ b/examples/pubsub-simple/subscriber.py
@@ -8,6 +8,6 @@ app = App()
 @app.subscribe(pubsub_name='pubsub', topic='TOPIC_A')
 def mytopic(event: v1.Event) -> None:
     data = json.loads(event.Data())
-    print(f'Subscriber received: id={data["id"]}, message="{data["message"]}"',flush=True)
+    print(f'Subscriber received: id={data["id"]}, message="{data["message"]}", content_type="{event.content_type}"',flush=True)
 
 app.run(50051)

--- a/tests/clients/fake_dapr_server.py
+++ b/tests/clients/fake_dapr_server.py
@@ -71,6 +71,9 @@ class FakeDaprSidecar(api_service_v1.DaprServicer):
         if request.data:
             headers = headers + (('hdata', request.data), )
             trailers = trailers + (('hdata', request.data), )
+        if request.data_content_type:
+            headers = headers + (('data_content_type', request.data_content_type), )
+            trailers = trailers + (('data_content_type', request.data_content_type), )
 
         context.send_initial_metadata(headers)
         context.set_trailing_metadata(trailers)

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -138,11 +138,24 @@ class DaprGrpcClientTests(unittest.TestCase):
         resp = dapr.publish_event(
             pubsub_name='pubsub',
             topic_name='example',
-            data=b'haha',
+            data=b'haha'
         )
 
         self.assertEqual(2, len(resp.headers))
         self.assertEqual(['haha'], resp.headers['hdata'])
+
+    def test_publish_event_with_content_type(self):
+        dapr = DaprGrpcClient(f'localhost:{self.server_port}')
+        resp = dapr.publish_event(
+            pubsub_name='pubsub',
+            topic_name='example',
+            data=b'{"foo": "bar"}',
+            data_content_type='application/json'
+        )
+
+        self.assertEqual(3, len(resp.headers))
+        self.assertEqual(['{"foo": "bar"}'], resp.headers['hdata'])
+        self.assertEqual(['application/json'], resp.headers['data_content_type'])
 
     def test_publish_error(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')


### PR DESCRIPTION
# Description

Python-sdk did not have a way to set data_content_type on a publish event. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #183

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
