### PR TITLE
Fix mypy to 0.812 for now

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 Flask>=1.1
-mypy>=0.761
+mypy==0.812
 mypy-extensions>=0.4.3
 flake8>=3.7.9 
 aiohttp>=3.6.2


### PR DESCRIPTION
# Description

It looks like mypy == 0.900 released some breaking changes. We can fix them with --install-types, however this blocks the terminal with a prompt (see python/mypy#10616 ). We'll have to let upstream add a --non-interactive option (coming in 0.910) before we can use this. Leaving at 0.812 fixes our build for now.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #225

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
