### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/ext/dapr-ext-fastapi"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/ext/dapr-ext-grpc"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/ext/flask_dapr"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,20 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/ext/dapr-ext-fastapi"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/ext/dapr-ext-grpc"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/ext/flask_dapr"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
# Description

This enables dependabot to ensure we do not use vulnerable dependencies.

As of April 2021 dependabot can also scan dependencies defined in `setup.cfg`.