### PR TITLE
Always use latest runtime and cli for sample validation

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "Found $RUNTIME_VERSION"
       - name: Determine latest Dapr Cli version
         run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" | jq '.[0].tag_name'| tr -d '",v')
+          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
       - name: Set up Python ${{ env.PYTHON_VER }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -15,17 +15,26 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHON_VER: 3.7
-      GOVER: 1.16.3
+      GOVER: 1.16
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      DAPR_CLI_VER: 1.2.0-rc.2
-      DAPR_RUNTIME_VER: 1.2.0-rc.5
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF:
       DAPR_REF: 
     steps:
       - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v1
+      - name: Determine latest Dapr Runtime version
+        run: |
+          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm show chart dapr/dapr --devel | grep "appVersion: [0-9]\+\.[0-9]\+\.[0-9]\+.*" | cut -d ' ' -f2)
+          echo "DAPR_RUNTIME_VER=$RUNTIME_VERSION" >> $GITHUB_ENV
+          echo "Found $RUNTIME_VERSION"
+      - name: Determine latest Dapr Cli version
+        run: |
+          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" | grep '"tag_name"' | cut -d ':' -f2 | tr -d '",v')
+          echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
+          echo "Found $CLI_VERSION"
       - name: Set up Python ${{ env.PYTHON_VER }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "Found $RUNTIME_VERSION"
       - name: Determine latest Dapr Cli version
         run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" | grep '"tag_name"' | cut -d ':' -f2 | tr -d '",v')
+          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" | jq '.[0].tag_name'| tr -d '",v')
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
       - name: Set up Python ${{ env.PYTHON_VER }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: azure/setup-helm@v1
       - name: Determine latest Dapr Runtime version
         run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm show chart dapr/dapr --devel | grep "appVersion: [0-9]\+\.[0-9]\+\.[0-9]\+.*" | cut -d ' ' -f2)
+          helm repo add dapr https://dapr.github.io/helm-charts/ && helm repo update && export RUNTIME_VERSION=$(helm search repo dapr/dapr --devel --versions | awk '/dapr\/dapr/ {print $3; exit}' )
           echo "DAPR_RUNTIME_VER=$RUNTIME_VERSION" >> $GITHUB_ENV
           echo "Found $RUNTIME_VERSION"
       - name: Determine latest Dapr Cli version


### PR DESCRIPTION
# Description

Always use latest runtime and cli for sample validation

This change was already deployed in the GO-SDK: https://github.com/dapr/go-sdk/pull/192/
You can see an example run from the past hour here: https://github.com/dapr/go-sdk/runs/3163493512?check_suite_focus=true