### PR TITLE
Fixes Actor Reminder Incorrect Period

### DIFF
--- a/dapr/actor/runtime/_reminder_data.py
+++ b/dapr/actor/runtime/_reminder_data.py
@@ -74,7 +74,7 @@ class ActorReminderData:
         return {
             'reminderName': self._reminder_name,
             'dueTime': self._due_time,
-            'period': self._due_time,
+            'period': self._period,
             'data': encoded_state.decode("utf-8"),
         }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 3.13.0
+    protobuf == 3.17.3
     grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1

--- a/tests/actor/test_reminder_data.py
+++ b/tests/actor/test_reminder_data.py
@@ -18,11 +18,11 @@ class ActorReminderTests(unittest.TestCase):
                 'test_reminder',
                 123,  # int type
                 timedelta(seconds=1),
-                timedelta(seconds=1))
+                timedelta(seconds=2))
             ActorReminderData(
                 'test_reminder',
                 'reminder_state',  # string type
-                timedelta(seconds=1),
+                timedelta(seconds=2),
                 timedelta(seconds=1))
 
     def test_valid_state(self):
@@ -31,7 +31,7 @@ class ActorReminderTests(unittest.TestCase):
             'test_reminder',
             b'reminder_state',
             timedelta(seconds=1),
-            timedelta(seconds=1))
+            timedelta(seconds=2))
         self.assertEqual(b'reminder_state', reminder.state)
 
     def test_as_dict(self):
@@ -39,11 +39,11 @@ class ActorReminderTests(unittest.TestCase):
             'test_reminder',
             b'reminder_state',
             timedelta(seconds=1),
-            timedelta(seconds=1))
+            timedelta(seconds=2))
         expected = {
             'reminderName': 'test_reminder',
             'dueTime': timedelta(seconds=1),
-            'period': timedelta(seconds=1),
+            'period': timedelta(seconds=2),
             'data': 'cmVtaW5kZXJfc3RhdGU=',
         }
         self.assertDictEqual(expected, reminder.as_dict())
@@ -51,10 +51,10 @@ class ActorReminderTests(unittest.TestCase):
     def test_from_dict(self):
         reminder = ActorReminderData.from_dict('test_reminder', {
             'dueTime': timedelta(seconds=1),
-            'period': timedelta(seconds=1),
+            'period': timedelta(seconds=2),
             'data': 'cmVtaW5kZXJfc3RhdGU=',
         })
         self.assertEqual('test_reminder', reminder.reminder_name)
         self.assertEqual(timedelta(seconds=1), reminder.due_time)
-        self.assertEqual(timedelta(seconds=1), reminder.period)
+        self.assertEqual(timedelta(seconds=2), reminder.period)
         self.assertEqual(b'reminder_state', reminder.state)


### PR DESCRIPTION
# Description

- The serialization of actor reminders incorrectly used the due time value for the period field. This is now fixed.
- Also bumping the library's protobuf version to be in line with dev requirement.

## Issue reference

Fixes #268
Fixes #271 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
