### PR TITLE
Remove explicit protobuf dep from example

### DIFF
--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -3,4 +3,3 @@ dapr-dev >= 1.3.0rc1.dev
 opencensus == 0.7.10
 opencensus-ext-grpc == 0.7.1
 opencensus-ext-zipkin == 0.2.2
-protobuf == 3.13.0


### PR DESCRIPTION
# Description

Removing the explicit protobuf dependency to avoid version mismatches. Dapr already provides the protobuf library.
