### PR TITLE
Fix dependency conflict: Bump protobuf version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 3.17.3
+    protobuf == 3.18.1
     grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1


### PR DESCRIPTION
There is a conflict between the pinned protobuf version and the version required by another dependency.

This addresses the issue and lets you build the Python SDK again.