### PR TITLE
Fix Dapr duration string parsing + new tests

### DIFF
--- a/dapr/serializers/util.py
+++ b/dapr/serializers/util.py
@@ -9,7 +9,7 @@ import re
 from datetime import timedelta
 
 # Regex to parse Go Duration datatype, e.g. 4h15m50s
-DAPR_DURATION_PARSER = re.compile(r'((?P<hours>\d+)h)?((?P<mins>\d+)m)?((?P<seconds>\d+)s)?')
+DAPR_DURATION_PARSER = re.compile(r'((?P<hours>\d+)h)?((?P<mins>\d+)m)?((?P<seconds>\d+)s)?$')
 
 
 def convert_from_dapr_duration(duration: str) -> timedelta:
@@ -24,7 +24,7 @@ def convert_from_dapr_duration(duration: str) -> timedelta:
 
     matched = DAPR_DURATION_PARSER.match(duration)
     if not matched or matched.lastindex == 0:
-        raise ValueError(f'Invalid Dapr Duartion format: \'{duration}\'')
+        raise ValueError(f'Invalid Dapr Duration format: \'{duration}\'')
 
     days = 0.0
     hours = 0.0

--- a/tests/serializers/test_util.py
+++ b/tests/serializers/test_util.py
@@ -6,10 +6,11 @@ Licensed under the MIT License.
 """
 
 import unittest
+import json
 from datetime import timedelta
 
 from dapr.serializers.util import convert_from_dapr_duration, convert_to_dapr_duration
-
+from dapr.serializers.json import DaprJSONDecoder
 
 class UtilTests(unittest.TestCase):
     def setUp(self):
@@ -28,12 +29,26 @@ class UtilTests(unittest.TestCase):
         self.assertEqual(delta.total_seconds(), 40.0)
 
     def test_convert_invalid_duration(self):
-        delta = convert_from_dapr_duration('invalid')
-        self.assertEqual(delta.total_seconds(), 0.0)
+        TESTSTRING = 'invalid'
+        try:
+            convert_from_dapr_duration(TESTSTRING)
+            self.fail('Expected ValueError')
+        except ValueError as e:
+            self.assertEqual(str(e), "Invalid Dapr Duration format: '{}'".format(TESTSTRING))
 
-    def test_convert_timedelta_to_dapr_duariton(self):
+    def test_convert_timedelta_to_dapr_duration(self):
         duration = convert_to_dapr_duration(timedelta(hours=4, minutes=15, seconds=40))
         self.assertEqual(duration, '4h15m40s')
+
+    def test_convert_invalid_duration_string(self):
+        TESTSTRING = '4h15m40shello'
+        try:
+            convert_from_dapr_duration(TESTSTRING)
+            self.fail('Expected ValueError')
+        except ValueError as e:
+            self.assertEqual(str(e), "Invalid Dapr Duration format: '{}'".format(TESTSTRING))
+        decoded = json.loads(json.dumps({"somevar": TESTSTRING}), cls=DaprJSONDecoder)
+        self.assertEqual(decoded['somevar'], TESTSTRING)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

Updated the regex for parsing go's time.duration strings. Unfortunately there is no clear ISO 8601 duration standard library for Python or implementation. In fact, even this duration standard is contested.

For now this PR focuses on fixing the observed problem in the referenced issue. We can consider a different approach in the future.

## Issue reference

Please reference the issue this PR will close: #283 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
