### PR TITLE
Add Python 3.10 to build/test matrix, bump protobuf version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9, 3.10]
+        python_ver: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python_ver }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9]
+        python_ver: [3.7, 3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python_ver }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9]
+        python_ver: [3.7, 3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v1

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9, 3.10]
+        python_ver: [3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: azure/setup-helm@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 3.18.1
+    protobuf == 3.19.1
     grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1


### PR DESCRIPTION
# Description

- Adds Python 3.10 to build / validate examples matrix
- bumps protobuf version in setup.cfg (manual step to sync with https://github.com/dapr/python-sdk/pull/291)