### PR TITLE
Add json deserialization convenience method

### DIFF
--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -155,7 +155,7 @@ class InvokeMethodResponse(DaprResponse):
         """
         return to_str(self.data)
 
-    def json(self) -> dict[str, object]:
+    def json(self) -> Dict[str, object]:
         """Gets the content as json if the response data content is not a serialized
         protocol buffer message.
 
@@ -244,7 +244,7 @@ class BindingResponse(DaprResponse):
         """Gets content as str."""
         return to_str(self._data)
 
-    def json(self) -> dict[str, object]:
+    def json(self) -> Dict[str, object]:
         """Gets content as deserialized JSON dictionary."""
         return json.loads(to_str(self._data))
 
@@ -355,7 +355,7 @@ class StateResponse(DaprResponse):
         """Gets content as str."""
         return to_str(self._data)
 
-    def json(self) -> dict[str, object]:
+    def json(self) -> Dict[str, object]:
         """Gets content as deserialized JSON dictionary."""
         return json.loads(to_str(self._data))
 
@@ -408,7 +408,7 @@ class BulkStateItem:
         """Gets content as str."""
         return to_str(self._data)
 
-    def json(self) -> dict[str, object]:
+    def json(self) -> Dict[str, object]:
         """Gets content as deserialized JSON dictionary."""
         return json.loads(to_str(self._data))
 

--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -20,6 +20,8 @@ from dapr.clients.grpc._helpers import (
     unpack,
 )
 
+import json
+
 
 class DaprResponse:
     """A base class for Dapr Response.
@@ -153,6 +155,15 @@ class InvokeMethodResponse(DaprResponse):
         """
         return to_str(self.data)
 
+    def json(self) -> dict[str, object]:
+        """Gets the content as json if the response data content is not a serialized
+        protocol buffer message.
+
+        Returns:
+            str: [description]
+        """
+        return json.loads(to_str(self.data))
+
     @property
     def content_type(self) -> Optional[str]:
         """Gets the content type of content attribute."""
@@ -232,6 +243,10 @@ class BindingResponse(DaprResponse):
     def text(self) -> str:
         """Gets content as str."""
         return to_str(self._data)
+
+    def json(self) -> dict[str, object]:
+        """Gets content as deserialized JSON dictionary."""
+        return json.loads(to_str(self._data))
 
     @property
     def data(self) -> bytes:
@@ -340,6 +355,10 @@ class StateResponse(DaprResponse):
         """Gets content as str."""
         return to_str(self._data)
 
+    def json(self) -> dict[str, object]:
+        """Gets content as deserialized JSON dictionary."""
+        return json.loads(to_str(self._data))
+
     @property
     def etag(self) -> str:
         """Gets etag."""
@@ -388,6 +407,10 @@ class BulkStateItem:
     def text(self) -> str:
         """Gets content as str."""
         return to_str(self._data)
+
+    def json(self) -> dict[str, object]:
+        """Gets content as deserialized JSON dictionary."""
+        return json.loads(to_str(self._data))
 
     @property
     def key(self) -> str:

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -397,7 +397,7 @@ class DaprGrpcClientTests(unittest.TestCase):
         dapr = DaprGrpcClient(f'localhost:{port}')
         with self.assertRaises(Exception) as context:
             dapr.wait(0.1)
-        self.assertTrue(type(context.exception) is socket.timeout)
+        self.assertTrue('Connection refused' in str(context.exception))
 
 
 if __name__ == '__main__':

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -397,7 +397,7 @@ class DaprGrpcClientTests(unittest.TestCase):
         dapr = DaprGrpcClient(f'localhost:{port}')
         with self.assertRaises(Exception) as context:
             dapr.wait(0.1)
-        self.assertTrue('Connection refused' in str(context.exception))
+        self.assertTrue(type(context.exception) is socket.timeout)
 
 
 if __name__ == '__main__':

--- a/tests/clients/test_dapr_grpc_response.py
+++ b/tests/clients/test_dapr_grpc_response.py
@@ -9,7 +9,10 @@ import unittest
 
 from google.protobuf.any_pb2 import Any as GrpcAny
 
-from dapr.clients.grpc._response import DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse
+from dapr.clients.grpc._response import (
+    DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse
+)
+
 from dapr.proto import common_v1
 
 
@@ -105,7 +108,7 @@ class StateResponseTests(unittest.TestCase):
         self.assertEqual('hello dapr', resp.text())
         self.assertEqual(b'hello dapr', resp.data)
 
-    def test_json_data(self):   
+    def test_json_data(self):
         resp = StateResponse(data=b'{"status": "ok"}')
         self.assertEqual({'status': 'ok'}, resp.json())
 

--- a/tests/clients/test_dapr_grpc_response.py
+++ b/tests/clients/test_dapr_grpc_response.py
@@ -9,7 +9,7 @@ import unittest
 
 from google.protobuf.any_pb2 import Any as GrpcAny
 
-from dapr.clients.grpc._response import DaprResponse, InvokeMethodResponse, BindingResponse
+from dapr.clients.grpc._response import DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse
 from dapr.proto import common_v1
 
 
@@ -64,6 +64,10 @@ class InvokeMethodResponseTests(unittest.TestCase):
         self.assertEqual('hello dapr', resp.text())
         self.assertEqual('application/json', resp.content_type)
 
+    def test_json_data(self):
+        resp = InvokeMethodResponse(data=b'{ "status": "ok" }', content_type='application/json')
+        self.assertEqual({'status': 'ok'}, resp.json())
+
     def test_unpack(self):
         # arrange
         fake_req = common_v1.InvokeRequest(method="test")
@@ -84,11 +88,26 @@ class InvokeBindingResponseTests(unittest.TestCase):
         self.assertEqual(b'data', resp.data)
         self.assertEqual('data', resp.text())
 
+    def test_json_data(self):
+        resp = BindingResponse(data=b'{"status": "ok"}', binding_metadata={})
+        self.assertEqual({'status': 'ok'}, resp.json())
+
     def test_metadata(self):
         resp = BindingResponse(data=b'data', binding_metadata={'status': 'ok'})
         self.assertEqual({'status': 'ok'}, resp.binding_metadata)
         self.assertEqual(b'data', resp.data)
         self.assertEqual('data', resp.text())
+
+
+class StateResponseTests(unittest.TestCase):
+    def test_data(self):
+        resp = StateResponse(data=b'hello dapr')
+        self.assertEqual('hello dapr', resp.text())
+        self.assertEqual(b'hello dapr', resp.data)
+
+    def test_json_data(self):   
+        resp = StateResponse(data=b'{"status": "ok"}')
+        self.assertEqual({'status': 'ok'}, resp.json())
 
 
 if __name__ == '__main__':

--- a/tests/clients/test_dapr_grpc_response.py
+++ b/tests/clients/test_dapr_grpc_response.py
@@ -10,7 +10,7 @@ import unittest
 from google.protobuf.any_pb2 import Any as GrpcAny
 
 from dapr.clients.grpc._response import (
-    DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse, 
+    DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse,
     BulkStateItem
 )
 

--- a/tests/clients/test_dapr_grpc_response.py
+++ b/tests/clients/test_dapr_grpc_response.py
@@ -10,7 +10,8 @@ import unittest
 from google.protobuf.any_pb2 import Any as GrpcAny
 
 from dapr.clients.grpc._response import (
-    DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse
+    DaprResponse, InvokeMethodResponse, BindingResponse, StateResponse, 
+    BulkStateItem
 )
 
 from dapr.proto import common_v1
@@ -111,6 +112,12 @@ class StateResponseTests(unittest.TestCase):
     def test_json_data(self):
         resp = StateResponse(data=b'{"status": "ok"}')
         self.assertEqual({'status': 'ok'}, resp.json())
+
+
+class BulkStateItemTests(unittest.TestCase):
+    def test_data(self):
+        item = BulkStateItem(key='item1', data=b'{ "status": "ok" }')
+        self.assertEqual({'status': 'ok'}, item.json())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

Adds the `json()` method to responses that contain data to deserialize the content to a dictionary. 
This should make the convenience layer a little bit easier to work with.

## Issue reference

Fixes #88

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
