### PR TITLE
Add publish_metadata field to publish_event api

### DIFF
--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -295,6 +295,7 @@ class DaprGrpcClient:
             pubsub_name: str,
             topic_name: str,
             data: Union[bytes, str],
+            publish_metadata: Dict[str, str] = {},
             metadata: Optional[MetadataTuple] = (),
             data_content_type: Optional[str] = None) -> DaprResponse:
         """Publish to a given topic.
@@ -311,6 +312,7 @@ class DaprGrpcClient:
                     pubsub_name='pubsub_1',
                     topic_name='TOPIC_A',
                     data=b'message',
+                    publish_metadata={'ttlInSeconds': '100', 'rawPayload': 'false'}
                     metadata=(
                         ('header1', 'value1')
                     ),
@@ -321,6 +323,7 @@ class DaprGrpcClient:
             pubsub_name (str): the name of the pubsub component
             topic_name (str): the topic name to publish to
             data (bytes or str): bytes or str for data
+            publish_metadata (Dict[str, str], optional): per message metadata
             metadata (tuple, optional): custom metadata
             data_content_type: (str, optional): content type of the data payload
 
@@ -344,7 +347,8 @@ class DaprGrpcClient:
             pubsub_name=pubsub_name,
             topic=topic_name,
             data=req_data,
-            data_content_type=content_type)
+            data_content_type=content_type,
+            metadata=publish_metadata)
 
         # response is google.protobuf.Empty
         _, call = self._stub.PublishEvent.with_call(req, metadata=metadata)

--- a/tests/clients/fake_dapr_server.py
+++ b/tests/clients/fake_dapr_server.py
@@ -75,6 +75,10 @@ class FakeDaprSidecar(api_service_v1.DaprServicer):
         if request.data_content_type:
             headers = headers + (('data_content_type', request.data_content_type), )
             trailers = trailers + (('data_content_type', request.data_content_type), )
+        if request.metadata['rawPayload']:
+            headers = headers + (('metadata_raw_payload', request.metadata['rawPayload']), )
+        if request.metadata['ttlInSeconds']:
+            headers = headers + (('metadata_ttl_in_seconds', request.metadata['ttlInSeconds']), )
 
         context.send_initial_metadata(headers)
         context.set_trailing_metadata(trailers)

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -158,6 +158,20 @@ class DaprGrpcClientTests(unittest.TestCase):
         self.assertEqual(['{"foo": "bar"}'], resp.headers['hdata'])
         self.assertEqual(['application/json'], resp.headers['data_content_type'])
 
+    def test_publish_event_with_metadata(self):
+        dapr = DaprGrpcClient(f'localhost:{self.server_port}')
+        resp = dapr.publish_event(
+            pubsub_name='pubsub',
+            topic_name='example',
+            data=b'{"foo": "bar"}',
+            publish_metadata={'ttlInSeconds': '100', 'rawPayload': 'false'}
+        )
+
+        print(resp.headers)
+        self.assertEqual(['{"foo": "bar"}'], resp.headers['hdata'])
+        self.assertEqual(['false'], resp.headers['metadata_raw_payload'])
+        self.assertEqual(['100'], resp.headers['metadata_ttl_in_seconds'])
+
     def test_publish_error(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')
         with self.assertRaisesRegex(ValueError, "invalid type for data <class 'int'>"):


### PR DESCRIPTION
# Description

The publish_event API was missing the publish_metadata field for options like ttlInSeconds and rawPayload.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #299
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
