### PR TITLE
Fix incorrect license configuration

### DIFF
--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -7,7 +7,7 @@ license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -7,7 +7,7 @@ license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -7,7 +7,7 @@ license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

It needs to be `OSI Approved :: Apache Software License` not `Apache License` in the `setup.cfg`.