### PR TITLE
Add topic event response support to GRPC ext client

### DIFF
--- a/examples/pubsub-simple/subscriber.py
+++ b/examples/pubsub-simple/subscriber.py
@@ -1,13 +1,15 @@
 from cloudevents.sdk.event import v1
 from dapr.ext.grpc import App
+from dapr.clients.grpc._response import TopicEventResponse
 
 import json
 
 app = App()
 
 @app.subscribe(pubsub_name='pubsub', topic='TOPIC_A')
-def mytopic(event: v1.Event) -> None:
+def mytopic(event: v1.Event) -> TopicEventResponse:
     data = json.loads(event.Data())
     print(f'Subscriber received: id={data["id"]}, message="{data["message"]}", content_type="{event.content_type}"',flush=True)
+    return TopicEventResponse('success')
 
 app.run(50051)

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/__init__.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/__init__.py
@@ -14,7 +14,7 @@ limitations under the License.
 """
 
 from dapr.clients.grpc._request import InvokeMethodRequest, BindingRequest
-from dapr.clients.grpc._response import InvokeMethodResponse
+from dapr.clients.grpc._response import InvokeMethodResponse, TopicEventResponse
 
 from dapr.ext.grpc.app import App, Rule   # type:ignore
 
@@ -25,4 +25,5 @@ __all__ = [
     'InvokeMethodRequest',
     'InvokeMethodResponse',
     'BindingRequest',
+    'TopicEventResponse',
 ]

--- a/ext/dapr-ext-grpc/tests/test_servicier.py
+++ b/ext/dapr-ext-grpc/tests/test_servicier.py
@@ -18,7 +18,7 @@ import unittest
 from unittest.mock import MagicMock, Mock
 
 from dapr.clients.grpc._request import InvokeMethodRequest
-from dapr.clients.grpc._response import InvokeMethodResponse
+from dapr.clients.grpc._response import InvokeMethodResponse, TopicEventResponse
 from dapr.ext.grpc._servicier import _CallbackServicer
 from dapr.proto import common_v1, appcallback_v1
 
@@ -93,6 +93,7 @@ class TopicSubscriptionTests(unittest.TestCase):
         self._topic1_method = Mock()
         self._topic2_method = Mock()
         self._topic3_method = Mock()
+        self._topic3_method.return_value = TopicEventResponse("success")
 
         self._servicier.register_topic(
             'pubsub1',
@@ -160,6 +161,17 @@ class TopicSubscriptionTests(unittest.TestCase):
         )
 
         self._topic3_method.assert_called_once()
+
+    def test_topic3_event_response(self):
+        response = self._servicier.OnTopicEvent(
+            appcallback_v1.TopicEventRequest(pubsub_name='pubsub1', topic='topic3'),
+            self.fake_context,
+        )
+        self.assertIsInstance(response, appcallback_v1.TopicEventResponse)
+        self.assertEqual(
+            response.status,
+            appcallback_v1.TopicEventResponse.TopicEventResponseStatus.SUCCESS
+        )
 
     def test_non_registered_topic(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
# Description

This PR enables responding to topic events from the GRPC ext client. This allows telling dapr whether messages:

 1. Were received successfully
 2. Should be retried later
 3. Should be dropped

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #336 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
