### PR TITLE
Always use existing asyncio event loop

### DIFF
--- a/dapr/clients/http/dapr_invocation_http_client.py
+++ b/dapr/clients/http/dapr_invocation_http_client.py
@@ -101,7 +101,10 @@ class DaprInvocationHttpClient:
                 resp_data.headers[key] = r.headers.getall(key)  # type: ignore
             return resp_data
 
-        loop = asyncio.new_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
         return loop.run_until_complete(make_request())

--- a/tests/actor/utils.py
+++ b/tests/actor/utils.py
@@ -13,6 +13,9 @@ def _async_mock(*args, **kwargs):
 
 
 def _run(coro):
-    loop = asyncio.new_event_loop()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     return loop.run_until_complete(coro)


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Fixes #295 

The DaprInvocationHttpClient did not use the existing eventloop if present, this causes problems in several scenarios, including Jupyter Notebooks.