### PR TITLE
Add option to disable topic validation

### DIFF
--- a/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-grpc.md
+++ b/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-grpc.md
@@ -88,6 +88,11 @@ def mytopic(event: v1.Event) -> Optional[TopicEventResponse]:
 def mytopic_important(event: v1.Event) -> None:
     print(event.Data(),flush=True)
 
+# Handler with disabled topic validation
+@app.subscribe(pubsub_name='pubsub-mqtt', topic='topic/#', disable_topic_validation=True,)
+def mytopic_wildcard(event: v1.Event) -> None:
+    print(event.Data(),flush=True)
+
 app.run(50051)
 ```
 

--- a/examples/pubsub-simple/README.md
+++ b/examples/pubsub-simple/README.md
@@ -29,10 +29,15 @@ name: Run subscriber
 expected_stdout_lines:
   - '== APP == Subscriber received: id=1, message="hello world", content_type="application/json"'
   - 'RETRY status returned from app while processing pub/sub event'
+  - '== APP == Wildcard-Subscriber received: id=1, message="hello world", content_type="application/json"'
   - '== APP == Subscriber received: id=2, message="hello world", content_type="application/json"'
+  - '== APP == Wildcard-Subscriber received: id=2, message="hello world", content_type="application/json"'
   - '== APP == Subscriber received: id=3, message="hello world", content_type="application/json"'
+  - '== APP == Wildcard-Subscriber received: id=3, message="hello world", content_type="application/json"'
   - '== APP == Subscriber received: id=4, message="hello world", content_type="application/json"'
+  - '== APP == Wildcard-Subscriber received: id=4, message="hello world", content_type="application/json"'
   - '== APP == Subscriber received: id=5, message="hello world", content_type="application/json"'
+  - '== APP == Wildcard-Subscriber received: id=5, message="hello world", content_type="application/json"'
 output_match_mode: substring
 background: true
 sleep: 5 

--- a/examples/pubsub-simple/publisher.py
+++ b/examples/pubsub-simple/publisher.py
@@ -32,6 +32,12 @@ with DaprClient() as d:
             data=json.dumps(req_data),
             data_content_type='application/json',
         )
+        resp = d.publish_event(
+            pubsub_name='pubsub',
+            topic_name=f'topic/{id}',
+            data=json.dumps(req_data),
+            data_content_type='application/json',
+        )
 
         # Print the request
         print(req_data, flush=True)

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/app.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/app.py
@@ -108,7 +108,7 @@ class App:
         return decorator
 
     def subscribe(self, pubsub_name: str, topic: str, metadata: Optional[Dict[str, str]] = {},
-                  rule: Optional[Rule] = None):
+                  rule: Optional[Rule] = None, disable_topic_validation: Optional[bool] = False):
         """A decorator that is used to register the subscribing topic method.
 
         The below example registers 'topic' subscription topic and pass custom
@@ -127,7 +127,8 @@ class App:
                 during initialization
         """
         def decorator(func):
-            self._servicer.register_topic(pubsub_name, topic, func, metadata, rule)
+            self._servicer.register_topic(pubsub_name, topic, func, metadata, rule,
+                                          disable_topic_validation)
         return decorator
 
     def binding(self, name: str):


### PR DESCRIPTION
Signed-off-by: Paul Thiele <paul.thiele@kinexon.com>

# Description

This PR adds the ability to optionally skip topic name validation for a given pub/sub.

Unblocks dapr/dapr#4461.

Also see: dapr/go-sdk/pull/271

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
