### PR TITLE
Bump development version to 1.7.0rc1.dev

### DIFF
--- a/dapr/version.py
+++ b/dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.5.0rc1.dev"
+__version__ = "1.7.0rc1.dev"

--- a/examples/demo_actor/demo_actor/requirements.txt
+++ b/examples/demo_actor/demo_actor/requirements.txt
@@ -1,1 +1,1 @@
-dapr-ext-fastapi-dev>=1.5.0rc1.dev
+dapr-ext-fastapi-dev>=1.7.0rc1.dev

--- a/examples/invoke-simple/requirements.txt
+++ b/examples/invoke-simple/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-grpc-dev >= 1.5.0rc1.dev
-dapr-dev >= 1.5.0rc1.dev
+dapr-ext-grpc-dev >= 1.7.0rc1.dev
+dapr-dev >= 1.7.0rc1.dev

--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -1,5 +1,5 @@
-dapr-ext-grpc-dev >= 1.5.0rc1.dev
-dapr-dev >= 1.5.0rc1.dev
+dapr-ext-grpc-dev >= 1.7.0rc1.dev
+dapr-dev >= 1.7.0rc1.dev
 opencensus == 0.7.10
 opencensus-ext-grpc == 0.7.1
 opencensus-ext-zipkin == 0.2.2

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.5.0rc1.dev"
+__version__ = "1.7.0rc1.dev"

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr-dev >= 1.5.0rc1.dev
+    dapr-dev >= 1.7.0rc1.dev
     uvicorn >= 0.11.6
     fastapi >= 0.60.1
 

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.5.0rc1.dev"
+__version__ = "1.7.0rc1.dev"

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr-dev >= 1.5.0rc1.dev
+    dapr-dev >= 1.7.0rc1.dev
     cloudevents >= 1.0.0
 
 [options.packages.find]

--- a/ext/flask_dapr/flask_dapr/version.py
+++ b/ext/flask_dapr/flask_dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.5.0rc1.dev"
+__version__ = "1.7.0rc1.dev"

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -25,4 +25,4 @@ include_package_data = true
 zip_safe = false
 install_requires =
     Flask >= 1.1
-    dapr-dev >= 1.5.0rc1.dev
+    dapr-dev >= 1.7.0rc1.dev


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Bump `dapr-dev`, `dapr-ext-fastapi-dev`, `dapr-ext-grpc-dev` , and `flask_dapr` development version to 1.7.0rc1.dev