### PR TITLE
Fix invoke binding example

### DIFF
--- a/daprdocs/content/en/python-sdk-docs/python-client.md
+++ b/daprdocs/content/en/python-sdk-docs/python-client.md
@@ -138,7 +138,7 @@ def mytopic_important(event: v1.Event) -> None:
 from dapr.clients import DaprClient
 
 with DaprClient() as d:
-    resp = d.invoke_binding(name='kafkaBinding', operation='create', data='{"message":"Hello World"}')
+    resp = d.invoke_binding(binding_name='kafkaBinding', operation='create', data='{"message":"Hello World"}')
 ```
 
 - For a full guide on output bindings visit [How-To: Use bindings]({{< ref howto-bindings.md >}}).


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

Fixes the invoke binding example which had a wrongly named parameter value. See https://github.com/dapr/docs/issues/1779