### PR TITLE
Make invoke request data params optional

### DIFF
--- a/dapr/clients/__init__.py
+++ b/dapr/clients/__init__.py
@@ -89,7 +89,7 @@ class DaprClient(DaprGrpcClient):
             self,
             app_id: str,
             method_name: str,
-            data: Union[bytes, str, GrpcMessage],
+            data: Union[bytes, str, GrpcMessage] = '',
             content_type: Optional[str] = None,
             metadata: Optional[MetadataTuple] = None,
             http_verb: Optional[str] = None,

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -219,8 +219,8 @@ class DaprGrpcClient:
         Args:
             app_id (str): the callee app id
             method (str): the method name which is called
-            data (bytes or :obj:`google.protobuf.message.Message`): bytes or Message for data
-                which will send to id
+            data (bytes or :obj:`google.protobuf.message.Message`, optional): bytes
+                or Message for data which will be sent to app id
             metadata (tuple, optional, DEPRECATED): gRPC custom metadata
             http_verb (str, optional): http method verb to call HTTP callee application
             http_querystring (tuple, optional): the tuple to represent query string

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -151,7 +151,7 @@ class DaprGrpcClient:
             self,
             app_id: str,
             method_name: str,
-            data: Union[bytes, str, GrpcMessage],
+            data: Optional[Union[bytes, str, GrpcMessage]] = '',
             content_type: Optional[str] = None,
             metadata: Optional[MetadataTuple] = None,
             http_verb: Optional[str] = None,
@@ -259,7 +259,7 @@ class DaprGrpcClient:
             self,
             binding_name: str,
             operation: str,
-            data: Union[bytes, str],
+            data: Optional[Union[bytes, str]] = '',
             binding_metadata: Dict[str, str] = {},
             metadata: Optional[MetadataTuple] = None) -> BindingResponse:
         """Invokes the output binding with the specified operation.
@@ -285,7 +285,7 @@ class DaprGrpcClient:
         Args:
             binding_name (str): the name of the binding as defined in the components
             operation (str): the operation to perform on the binding
-            data (bytes or str): bytes or str for data which will sent to the binding
+            data (bytes or str, optional): bytes or str for data which will sent to the binding
             binding_metadata (dict, optional): Dapr metadata for output binding
             metadata (tuple, optional, DEPRECATED): gRPC custom metadata
 

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -151,7 +151,7 @@ class DaprGrpcClient:
             self,
             app_id: str,
             method_name: str,
-            data: Optional[Union[bytes, str, GrpcMessage]] = '',
+            data: Union[bytes, str, GrpcMessage] = '',
             content_type: Optional[str] = None,
             metadata: Optional[MetadataTuple] = None,
             http_verb: Optional[str] = None,
@@ -259,7 +259,7 @@ class DaprGrpcClient:
             self,
             binding_name: str,
             operation: str,
-            data: Optional[Union[bytes, str]] = '',
+            data: Union[bytes, str] = '',
             binding_metadata: Dict[str, str] = {},
             metadata: Optional[MetadataTuple] = None) -> BindingResponse:
         """Invokes the output binding with the specified operation.

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -86,6 +86,24 @@ class DaprGrpcClientTests(unittest.TestCase):
         self.assertEqual(3, len(resp.headers))
         self.assertEqual(['value1'], resp.headers['hkey1'])
 
+    def test_invoke_method_no_data(self):
+        dapr = DaprGrpcClient(f'localhost:{self.server_port}')
+        resp = dapr.invoke_method(
+            app_id='targetId',
+            method_name='bytes',
+            content_type="text/plain",
+            metadata=(
+                ('key1', 'value1'),
+                ('key2', 'value2'),
+            ),
+            http_verb='PUT',
+        )
+
+        self.assertEqual(b'', resp.data)
+        self.assertEqual("text/plain", resp.content_type)
+        self.assertEqual(3, len(resp.headers))
+        self.assertEqual(['value1'], resp.headers['hkey1'])
+
     def test_invoke_method_async(self):
         dapr = DaprClient(f'localhost:{self.server_port}')
         dapr.invocation_client = None  # force to use grpc client
@@ -155,6 +173,17 @@ class DaprGrpcClientTests(unittest.TestCase):
         )
 
         self.assertEqual(b'haha', resp.data)
+        self.assertEqual({}, resp.binding_metadata)
+        self.assertEqual(0, len(resp.headers))
+
+    def test_invoke_binding_no_data(self):
+        dapr = DaprGrpcClient(f'localhost:{self.server_port}')
+        resp = dapr.invoke_binding(
+            binding_name='binding',
+            operation='create',
+        )
+
+        self.assertEqual(b'', resp.data)
         self.assertEqual({}, resp.binding_metadata)
         self.assertEqual(0, len(resp.headers))
 


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Makes the `Invoke Method` and `Invoke Binding` param `data` optional (defaulting to the empty string)

## Issue reference

fixes #399 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
