### PR TITLE
Return headers for HTTP service invocation

### DIFF
--- a/dapr/clients/http/dapr_invocation_http_client.py
+++ b/dapr/clients/http/dapr_invocation_http_client.py
@@ -97,8 +97,12 @@ class DaprInvocationHttpClient:
                 query_params=query_params)
 
             resp_data = InvokeMethodResponse(resp_body, r.content_type)
+            respHeaders = resp_data.headers
             for key in r.headers:
-                resp_data.headers[key] = r.headers.getall(key)  # type: ignore
+                respHeaders.setdefault(key, []).append(r.headers[key])
+
+            headerTuples = tuple((k, v) for k, v in respHeaders.items())
+            resp_data.headers = headerTuples  # type: ignore
             return resp_data
         return await make_request()
 

--- a/dapr/clients/http/dapr_invocation_http_client.py
+++ b/dapr/clients/http/dapr_invocation_http_client.py
@@ -101,7 +101,7 @@ class DaprInvocationHttpClient:
             for key in r.headers:
                 respHeaders[key] = r.headers[key]  # type: ignore
 
-            headerTuples = tuple((k, v) for k, v in respHeaders.items())
+            headerTuples = [(k, v) for k, v in respHeaders.items()]
             resp_data.headers = headerTuples  # type: ignore
             return resp_data
         return await make_request()

--- a/dapr/clients/http/dapr_invocation_http_client.py
+++ b/dapr/clients/http/dapr_invocation_http_client.py
@@ -99,7 +99,7 @@ class DaprInvocationHttpClient:
             resp_data = InvokeMethodResponse(resp_body, r.content_type)
             respHeaders = resp_data.headers
             for key in r.headers:
-                respHeaders.setdefault(key, []).append(r.headers[key])
+                respHeaders[key] = r.headers[key]  # type: ignore
 
             headerTuples = tuple((k, v) for k, v in respHeaders.items())
             resp_data.headers = headerTuples  # type: ignore

--- a/tests/clients/test_http_service_invocation_client.py
+++ b/tests/clients/test_http_service_invocation_client.py
@@ -137,6 +137,7 @@ class DaprInvocationHttpClientTests(unittest.TestCase):
         self.assertEqual(b"\x0a\x04test", self.server.get_request_body())
         # unpack to new protobuf object
         new_resp = common_v1.StateItem()
+        self.assertEqual(resp.headers['Content-Type'], ['application/x-protobuf'])
         resp.unpack(new_resp)
         self.assertEqual('resp', new_resp.key)
 


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Correctly populates the response headers for HTTP service invocation.

## Issue reference

Fixes #398

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
