### PR TITLE
Add FastAPI router tags for OpenAPI docs

### DIFF
--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
@@ -26,6 +26,9 @@ from dapr.serializers import DefaultJSONSerializer
 DEFAULT_CONTENT_TYPE = "application/json; utf-8"
 DAPR_REENTRANCY_ID_HEADER = 'Dapr-Reentrancy-Id'
 
+# This should be added to all magic Dapr Actor methods implemented here
+DEFAULT_ACTOR_ROUTER_TAGS: List[str] = ['Actor']
+
 
 def _wrap_response(
         status_code: int,
@@ -48,11 +51,10 @@ def _wrap_response(
 
 
 class DaprActor(object):
-    _DEFAULT_ACTOR_ROUTER_TAGS: List[str] = ['Actor']
 
     def __init__(self, app: FastAPI,
-                 router_tags: Optional[List[str]] = None):
-        self._router_tags = router_tags if router_tags else self._DEFAULT_ACTOR_ROUTER_TAGS
+                 router_tags: Optional[List[str]] = DEFAULT_ACTOR_ROUTER_TAGS):
+        self._router_tags = router_tags
         self._router = APIRouter()
         self._dapr_serializer = DefaultJSONSerializer()
         self.init_routes(self._router)

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, List
 
 from fastapi import FastAPI, APIRouter, Request, Response, status   # type: ignore
 from fastapi.logger import logger
@@ -48,23 +48,27 @@ def _wrap_response(
 
 
 class DaprActor(object):
-    def __init__(self, app: FastAPI):
-        self._dapr_serializer = DefaultJSONSerializer()
+    _DEFAULT_ACTOR_ROUTER_TAGS: List[str] = ['Actor']
+
+    def __init__(self, app: FastAPI,
+                 router_tags: Optional[List[str]] = None):
+        self._router_tags = router_tags if router_tags else self._DEFAULT_ACTOR_ROUTER_TAGS
         self._router = APIRouter()
+        self._dapr_serializer = DefaultJSONSerializer()
         self.init_routes(self._router)
         app.include_router(self._router)
 
     def init_routes(self, router: APIRouter):
-        @router.get("/healthz")
+        @router.get("/healthz", tags=self._router_tags)
         async def healthz():
             return {'status': 'ok'}
 
-        @router.get('/dapr/config')
+        @router.get('/dapr/config', tags=self._router_tags)
         async def dapr_config():
             serialized = self._dapr_serializer.serialize(ActorRuntime.get_actor_config())
             return _wrap_response(status.HTTP_200_OK, serialized)
 
-        @router.delete('/actors/{actor_type_name}/{actor_id}')
+        @router.delete('/actors/{actor_type_name}/{actor_id}', tags=self._router_tags)
         async def actor_deactivation(actor_type_name: str, actor_id: str):
             try:
                 await ActorRuntime.deactivate(actor_type_name, actor_id)
@@ -82,7 +86,8 @@ class DaprActor(object):
             logger.debug(msg)
             return _wrap_response(status.HTTP_200_OK, msg)
 
-        @router.put('/actors/{actor_type_name}/{actor_id}/method/{method_name}')
+        @router.put('/actors/{actor_type_name}/{actor_id}/method/{method_name}',
+                    tags=self._router_tags)
         async def actor_method(
                 actor_type_name: str,
                 actor_id: str,
@@ -107,7 +112,8 @@ class DaprActor(object):
             logger.debug(msg)
             return _wrap_response(status.HTTP_200_OK, result)
 
-        @router.put('/actors/{actor_type_name}/{actor_id}/method/timer/{timer_name}')
+        @router.put('/actors/{actor_type_name}/{actor_id}/method/timer/{timer_name}',
+                    tags=self._router_tags)
         async def actor_timer(
                 actor_type_name: str,
                 actor_id: str,
@@ -131,7 +137,8 @@ class DaprActor(object):
             logger.debug(msg)
             return _wrap_response(status.HTTP_200_OK, msg)
 
-        @router.put('/actors/{actor_type_name}/{actor_id}/method/remind/{reminder_name}')
+        @router.put('/actors/{actor_type_name}/{actor_id}/method/remind/{reminder_name}',
+                    tags=self._router_tags)
         async def actor_reminder(
                 actor_type_name: str,
                 actor_id: str,

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/actor.py
@@ -26,9 +26,6 @@ from dapr.serializers import DefaultJSONSerializer
 DEFAULT_CONTENT_TYPE = "application/json; utf-8"
 DAPR_REENTRANCY_ID_HEADER = 'Dapr-Reentrancy-Id'
 
-# This should be added to all magic Dapr Actor methods implemented here
-DEFAULT_ACTOR_ROUTER_TAGS: List[str] = ['Actor']
-
 
 def _wrap_response(
         status_code: int,
@@ -53,7 +50,8 @@ def _wrap_response(
 class DaprActor(object):
 
     def __init__(self, app: FastAPI,
-                 router_tags: Optional[List[str]] = DEFAULT_ACTOR_ROUTER_TAGS):
+                 router_tags: Optional[List[str]] = ['Actor']):
+        # router_tags should be added to all magic Dapr Actor methods implemented here
         self._router_tags = router_tags
         self._router = APIRouter()
         self._dapr_serializer = DefaultJSONSerializer()

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
@@ -24,13 +24,18 @@ class DaprApp:
         app_instance: The FastAPI instance to wrap.
     """
 
-    def __init__(self, app_instance: FastAPI):
+    _DEFAULT_ROUTER_TAGS: List[str] = ['PubSub']
+
+    def __init__(self, app_instance: FastAPI,
+                 router_tags: Optional[List[str]] = None):
+        self._router_tags = router_tags if router_tags else self._DEFAULT_ROUTER_TAGS
         self._app = app_instance
         self._subscriptions: List[Dict[str, object]] = []
 
         self._app.add_api_route("/dapr/subscribe",
                                 self._get_subscriptions,
-                                methods=["GET"])
+                                methods=["GET"],
+                                tags=self._router_tags)
 
     def subscribe(self,
                   pubsub: str,
@@ -69,7 +74,8 @@ class DaprApp:
 
             self._app.add_api_route(event_handler_route,
                                     func,
-                                    methods=["POST"])
+                                    methods=["POST"],
+                                    tags = self._router_tags)
 
             self._subscriptions.append({
                 "pubsubname": pubsub,

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
@@ -15,9 +15,6 @@ limitations under the License.
 from typing import Dict, List, Optional
 from fastapi import FastAPI  # type: ignore
 
-# This should be added to all magic Dapr App PubSub methods implemented here
-DEFAULT_ROUTER_TAGS: List[str] = ['PubSub']
-
 
 class DaprApp:
     """
@@ -28,7 +25,8 @@ class DaprApp:
     """
 
     def __init__(self, app_instance: FastAPI,
-                 router_tags: Optional[List[str]] = DEFAULT_ROUTER_TAGS):
+                 router_tags: Optional[List[str]] = ['PubSub']):
+        # The router_tags should be added to all magic Dapr App PubSub methods implemented here
         self._router_tags = router_tags
         self._app = app_instance
         self._subscriptions: List[Dict[str, object]] = []

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
@@ -15,6 +15,9 @@ limitations under the License.
 from typing import Dict, List, Optional
 from fastapi import FastAPI  # type: ignore
 
+# This should be added to all magic Dapr App PubSub methods implemented here
+DEFAULT_ROUTER_TAGS: List[str] = ['PubSub']
+
 
 class DaprApp:
     """
@@ -24,11 +27,9 @@ class DaprApp:
         app_instance: The FastAPI instance to wrap.
     """
 
-    _DEFAULT_ROUTER_TAGS: List[str] = ['PubSub']
-
     def __init__(self, app_instance: FastAPI,
-                 router_tags: Optional[List[str]] = None):
-        self._router_tags = router_tags if router_tags else self._DEFAULT_ROUTER_TAGS
+                 router_tags: Optional[List[str]] = DEFAULT_ROUTER_TAGS):
+        self._router_tags = router_tags
         self._app = app_instance
         self._subscriptions: List[Dict[str, object]] = []
 

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/app.py
@@ -75,7 +75,7 @@ class DaprApp:
             self._app.add_api_route(event_handler_route,
                                     func,
                                     methods=["POST"],
-                                    tags = self._router_tags)
+                                    tags=self._router_tags)
 
             self._subscriptions.append({
                 "pubsubname": pubsub,

--- a/ext/dapr-ext-fastapi/tests/test_app.py
+++ b/ext/dapr-ext-fastapi/tests/test_app.py
@@ -82,6 +82,36 @@ class DaprAppTest(unittest.TestCase):
         response = self.client.post("/events/pubsub/test", json={"body": "new message"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, '"custom metadata"')
+    
+    def test_router_tag(self):
+        app1 = FastAPI()
+        app2 = FastAPI()
+        DaprApp(app_instance=app1, router_tags=['MyTag', 'PubSub']).subscribe(
+            pubsub="mypubsub", topic="test")
+        DaprApp(app_instance=app2).subscribe(pubsub="mypubsub", topic="test")
+
+        PATHS_WITH_EXPECTED_TAGS = [
+            '/dapr/subscribe',
+            '/events/mypubsub/test'
+        ]
+
+        foundTags = False
+        for route in app1.router.routes:
+            if hasattr(route, "tags"):
+                self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
+                self.assertEqual(['MyTag', 'PubSub'], route.tags)
+                foundTags = True
+        if not foundTags:
+            self.fail('No tags found')
+        
+        foundTags = False
+        for route in app2.router.routes:
+            if hasattr(route, "tags"):
+                self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
+                self.assertEqual(['PubSub'], route.tags)
+                foundTags=True
+        if not foundTags:
+            self.fail('No tags found')
 
 
 if __name__ == '__main__':

--- a/ext/dapr-ext-fastapi/tests/test_app.py
+++ b/ext/dapr-ext-fastapi/tests/test_app.py
@@ -115,7 +115,6 @@ class DaprAppTest(unittest.TestCase):
         if not foundTags:
             self.fail('No tags found')
 
-        foundTags = False
         for route in app3.router.routes:
             if hasattr(route, "tags"):
                 if len(route.tags) > 0:

--- a/ext/dapr-ext-fastapi/tests/test_app.py
+++ b/ext/dapr-ext-fastapi/tests/test_app.py
@@ -86,9 +86,11 @@ class DaprAppTest(unittest.TestCase):
     def test_router_tag(self):
         app1 = FastAPI()
         app2 = FastAPI()
+        app3 = FastAPI()
         DaprApp(app_instance=app1, router_tags=['MyTag', 'PubSub']).subscribe(
             pubsub="mypubsub", topic="test")
         DaprApp(app_instance=app2).subscribe(pubsub="mypubsub", topic="test")
+        DaprApp(app_instance=app3, router_tags=None).subscribe(pubsub="mypubsub", topic="test")
 
         PATHS_WITH_EXPECTED_TAGS = [
             '/dapr/subscribe',
@@ -112,6 +114,12 @@ class DaprAppTest(unittest.TestCase):
                 foundTags = True
         if not foundTags:
             self.fail('No tags found')
+
+        foundTags = False
+        for route in app3.router.routes:
+            if hasattr(route, "tags"):
+                if len(route.tags) > 0:
+                    self.fail('Found tags on route that should not have any')
 
 
 if __name__ == '__main__':

--- a/ext/dapr-ext-fastapi/tests/test_app.py
+++ b/ext/dapr-ext-fastapi/tests/test_app.py
@@ -82,7 +82,7 @@ class DaprAppTest(unittest.TestCase):
         response = self.client.post("/events/pubsub/test", json={"body": "new message"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, '"custom metadata"')
-    
+
     def test_router_tag(self):
         app1 = FastAPI()
         app2 = FastAPI()
@@ -103,13 +103,13 @@ class DaprAppTest(unittest.TestCase):
                 foundTags = True
         if not foundTags:
             self.fail('No tags found')
-        
+
         foundTags = False
         for route in app2.router.routes:
             if hasattr(route, "tags"):
                 self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
                 self.assertEqual(['PubSub'], route.tags)
-                foundTags=True
+                foundTags = True
         if not foundTags:
             self.fail('No tags found')
 

--- a/ext/dapr-ext-fastapi/tests/test_dapractor.py
+++ b/ext/dapr-ext-fastapi/tests/test_dapractor.py
@@ -47,8 +47,10 @@ class DaprActorTest(unittest.TestCase):
     def test_router_tag(self):
         app1 = FastAPI()
         app2 = FastAPI()
+        app3 = FastAPI()
         DaprActor(app=app1, router_tags=['MyTag', 'Actor'])
         DaprActor(app=app2)
+        DaprActor(app=app3, router_tags=None)
 
         PATHS_WITH_EXPECTED_TAGS = [
             '/healthz',
@@ -76,6 +78,12 @@ class DaprActorTest(unittest.TestCase):
                 foundTags = True
         if not foundTags:
             self.fail('No tags found')
+
+        foundTags = False
+        for route in app3.router.routes:
+            if hasattr(route, "tags"):
+                if len(route.tags) > 0:
+                    self.fail('Found tags on route that should not have any')
 
 
 if __name__ == '__main__':

--- a/ext/dapr-ext-fastapi/tests/test_dapractor.py
+++ b/ext/dapr-ext-fastapi/tests/test_dapractor.py
@@ -43,7 +43,7 @@ class DaprActorTest(unittest.TestCase):
         r = _wrap_response(200, fake_data)
         self.assertEqual(fake_data, json.loads(r.body))
         self.assertEqual(200, r.status_code)
-    
+
     def test_router_tag(self):
         app1 = FastAPI()
         app2 = FastAPI()
@@ -67,13 +67,13 @@ class DaprActorTest(unittest.TestCase):
                 foundTags = True
         if not foundTags:
             self.fail('No tags found')
-        
+
         foundTags = False
         for route in app2.router.routes:
             if hasattr(route, "tags"):
                 self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
                 self.assertEqual(['Actor'], route.tags)
-                foundTags=True
+                foundTags = True
         if not foundTags:
             self.fail('No tags found')
 

--- a/ext/dapr-ext-fastapi/tests/test_dapractor.py
+++ b/ext/dapr-ext-fastapi/tests/test_dapractor.py
@@ -79,7 +79,6 @@ class DaprActorTest(unittest.TestCase):
         if not foundTags:
             self.fail('No tags found')
 
-        foundTags = False
         for route in app3.router.routes:
             if hasattr(route, "tags"):
                 if len(route.tags) > 0:

--- a/ext/dapr-ext-fastapi/tests/test_dapractor.py
+++ b/ext/dapr-ext-fastapi/tests/test_dapractor.py
@@ -16,7 +16,9 @@ limitations under the License.
 import json
 import unittest
 
-from dapr.ext.fastapi.actor import _wrap_response
+from fastapi import FastAPI
+
+from dapr.ext.fastapi.actor import DaprActor, _wrap_response
 
 
 class DaprActorTest(unittest.TestCase):
@@ -41,6 +43,39 @@ class DaprActorTest(unittest.TestCase):
         r = _wrap_response(200, fake_data)
         self.assertEqual(fake_data, json.loads(r.body))
         self.assertEqual(200, r.status_code)
+    
+    def test_router_tag(self):
+        app1 = FastAPI()
+        app2 = FastAPI()
+        DaprActor(app=app1, router_tags=['MyTag', 'Actor'])
+        DaprActor(app=app2)
+
+        PATHS_WITH_EXPECTED_TAGS = [
+            '/healthz',
+            '/dapr/config',
+            '/actors/{actor_type_name}/{actor_id}',
+            '/actors/{actor_type_name}/{actor_id}/method/{method_name}',
+            '/actors/{actor_type_name}/{actor_id}/method/timer/{timer_name}',
+            '/actors/{actor_type_name}/{actor_id}/method/remind/{reminder_name}'
+        ]
+
+        foundTags = False
+        for route in app1.router.routes:
+            if hasattr(route, "tags"):
+                self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
+                self.assertEqual(['MyTag', 'Actor'], route.tags)
+                foundTags = True
+        if not foundTags:
+            self.fail('No tags found')
+        
+        foundTags = False
+        for route in app2.router.routes:
+            if hasattr(route, "tags"):
+                self.assertIn(route.path, PATHS_WITH_EXPECTED_TAGS)
+                self.assertEqual(['Actor'], route.tags)
+                foundTags=True
+        if not foundTags:
+            self.fail('No tags found')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Implements default Flask API Router Tags and the ability to customize these for Dapr Actor endpoints and Dapr PubSub endpoints in the Dapr Fast API extension. This is only used when generating OpenAPI documentation. (See referenced issue)

## Issue reference

Closes #401

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
