### PR TITLE
Revert Protobuf upgrade due to grpctools incompatibility 

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ aiohttp>=3.6.2
 python-dateutil>=2.8.1
 grpcio>=1.26.0
 grpcio-tools>=1.26.0
-protobuf==4.21.1
+protobuf==3.20.1
 six==1.16.0
 tox == 3.25.0
 cloudevents >= 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 3.20.1
+    protobuf == 4.21.1
     grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find_namespace:
 include_package_data = True
 zip_safe = False
 install_requires =
-    protobuf == 4.21.1
+    protobuf == 3.20.1
     grpcio >= 1.26.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1


### PR DESCRIPTION
Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>

# Description

Dependabot does not update setup.cfg unfortunately so this manual PR is required.