### PR TITLE
Removes a left over merge conflict marker.

### DIFF
--- a/examples/demo_actor/README.md
+++ b/examples/demo_actor/README.md
@@ -137,11 +137,7 @@ expected_stdout_lines:
 
 > For example, [docker registry] is docker hub account.
 
-<<<<<<< HEAD
-2. Follow [these steps](https://docs.dapr.io/reference/components-reference/supported-configuration-stores/redis-configuration-store/#setup-redis) to create a Redis store.
-=======
 2. Follow [these steps](https://docs.dapr.io/getting-started/tutorials/configure-state-pubsub/#step-1-create-a-redis-store) to create a Redis store.
->>>>>>> c8f4e5d (Fixed external link validation)
 
 3. Once your store is created,  confirm validate `redis.yml` file in the `deploy` directory. 
     > **Note:** the `redis.yml` uses the secret created by `bitmany/redis` Helm chat to securely inject the password.


### PR DESCRIPTION
# Description

Removes a left over merge conflict marker.

File `examples/demo_actor/README.md` has a merge-conflict markers left on it:

https://github.com/dapr/python-sdk/blob/c994ca5330b0b34bf448fcd9632056a501c56de0/examples/demo_actor/README.md?plain=1#L140-L144

This PR addresses it.

## Issue reference

Closes #433 

## Checklist

* ~~[ ] Code compiles correctly~~ Not applicable
* ~~[ ] Created/updated tests~~  Not applicable
* [x] Extended the documentation
