### PR TITLE
Metadata API support for Python GRPC clients.

### DIFF
--- a/dapr/clients/grpc/_helpers.py
+++ b/dapr/clients/grpc/_helpers.py
@@ -170,6 +170,11 @@ class DaprClientInterceptor(UnaryUnaryClientInterceptor):
 
 # Data validation helpers
 
+def validateNotNone(**kwargs: Optional[str]):
+    for field_name, value in kwargs.items():
+        if value is None:
+            raise ValueError(f"{field_name} name cannot be None")
+
 
 def validateNotBlankString(**kwargs: Optional[str]):
     for field_name, value in kwargs.items():

--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from enum import Enum
-from typing import Dict, Optional, Union, Sequence, List, TYPE_CHECKING
+from typing import Dict, Optional, Union, Sequence, List, TYPE_CHECKING, NamedTuple
 
 from google.protobuf.any_pb2 import Any as GrpcAny
 from google.protobuf.message import Message as GrpcMessage
@@ -851,3 +851,69 @@ class TryLockResponse(contextlib.AbstractContextManager, DaprResponse):
         if self._success:
             self._client.unlock(self._store_name, self._resource_id, self._lock_owner)
         # else: there is no point unlocking a lock we did not acquire.
+
+
+class GetMetadataResponse(DaprResponse):
+    '''GetMetadataResponse is a message that is returned on GetMetadata rpc call.'''
+
+    def __init__(
+        self,
+        application_id: str,
+        active_actors_count: Dict[str, int],
+        registered_components: Sequence[RegisteredComponents],
+        extended_metadata: Dict[str, str],
+        headers: MetadataTuple = (),
+    ):
+        '''Initializes GetMetadataResponse.
+
+        Args:
+            application_id (str): The Application ID.
+            active_actors_count (Dict[str, int]): mapping from the type of
+                    registered actors to their number of running instances.
+            registered_components (Sequence[RegisteredComponents]): list of
+                    loaded components metadata.
+            extended_metadata (Dict[str, str]): mapping of custom (extended)
+                    attributes to their respective values.
+            headers (Tuple, optional): the headers from Dapr gRPC response.
+        '''
+        super().__init__(headers)
+        self._application_id = application_id
+        self._active_actors_count = active_actors_count
+        self._registered_components = registered_components
+        self._extended_metadata = extended_metadata
+
+    @property
+    def application_id(self) -> str:
+        '''The Application ID.'''
+        return self._application_id
+
+    @property
+    def active_actors_count(self) -> Dict[str, int]:
+        '''Mapping from the type of registered actors to their number of running instances.'''
+        return self._active_actors_count
+
+    @property
+    def registered_components(self) -> Sequence[RegisteredComponents]:
+        '''List of loaded components metadata.'''
+        return self._registered_components
+
+    @property
+    def extended_metadata(self) -> Dict[str, str]:
+        '''Mapping of custom (extended) attributes to their respective values.'''
+        return self._extended_metadata
+
+
+class RegisteredComponents(NamedTuple):
+    '''Describes a loaded Dapr component.'''
+
+    name: str
+    '''Name of the component.'''
+
+    type: str
+    '''Component type.'''
+
+    version: str
+    '''Component version.'''
+
+    capabilities: Sequence[str]
+    '''Supported capabilities for this component type and version.'''

--- a/examples/metadata/README.md
+++ b/examples/metadata/README.md
@@ -1,0 +1,62 @@
+# Example - Inspect Dapr runtime metadata
+
+This example demonstrates the usage of Dapr [Metadata API] and of the two
+two methods in that API:
+1. **get_metadata**: Gets the Dapr sidecar information provided by the Metadata
+   Endpoint.
+2. **set_metadata**: Adds a custom label to the Dapr sidecar information stored
+   by the Metadata endpoint.
+
+It creates a client using `DaprClient`, uses a set of components defined in the 
+[`./components/`](./components/) folder and invokes the two APIs from
+[Metadata API].
+
+
+## Pre-requisites
+
+- [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
+- [Install Python 3.7+](https://www.python.org/downloads/)
+
+## Install Dapr python-SDK
+
+<!-- Our CI/CD pipeline automatically installs the correct version, so we can skip this step in the automation -->
+
+```bash
+pip3 install dapr dapr-ext-grpc
+```
+
+## Run the example
+
+To run this example, the following code can be utilized:
+
+<!-- STEP
+name: Run metadata example
+expected_stdout_lines:
+  - "== APP == First, we will assign a new custom label to Dapr sidecar"
+  - "== APP == Now, we will fetch the sidecar's metadata"
+  - "== APP == We will update our custom label value and check it was persisted"
+  - "== APP == We added a custom label named [is-this-our-metadata-example]"
+  - "== APP == Its old value was [yes] but now it is [You bet it is!]"
+timeout_seconds: 10
+-->
+
+```bash
+dapr run --app-id=my-metadata-app --app-protocol grpc --components-path components/ python3 app.py
+```
+<!-- END_STEP -->
+
+The output should be as follows:
+
+```
+== APP == First, we will assign a new custom label to Dapr sidecar
+== APP == Now, we will fetch the sidecar's metadata
+== APP == We will update our custom label value and check it was persisted
+== APP == We added a custom label named [is-this-our-metadata-example]
+== APP == Its old value was [yes] but now it is [You bet it is!]
+```
+
+## Error Handling
+
+The Dapr python-sdk will pass through errors that it receives from the Dapr runtime.
+
+[Metadata API]: https://docs.dapr.io/reference/api/metadata_api/

--- a/examples/metadata/app.py
+++ b/examples/metadata/app.py
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+from dapr.clients import DaprClient
+
+
+def main():
+    extended_attribute_name = 'is-this-our-metadata-example'
+
+    with DaprClient() as dapr:
+        print("First, we will assign a new custom label to Dapr sidecar")
+        # We do this so example can be made deterministic across
+        # multiple invocations.
+        original_value = 'yes'
+        dapr.set_metadata(extended_attribute_name, original_value)
+
+        print("Now, we will fetch the sidecar's metadata")
+        metadata = dapr.get_metadata()
+        old_value = metadata.extended_metadata[extended_attribute_name]
+
+        print("We will update our custom label value and check it was persisted")
+        dapr.set_metadata(extended_attribute_name, 'You bet it is!')
+        metadata = dapr.get_metadata()
+        new_value = metadata.extended_metadata[extended_attribute_name]
+        print("We added a custom label named [%s]" % extended_attribute_name)
+        print("Its old value was [%s] but now it is [%s]" % (old_value, new_value))
+
+        print("And we are done 👋", flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/metadata/components/lockstore.yaml
+++ b/examples/metadata/components/lockstore.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: lockstore
+  namespace: default
+spec:
+  type: lock.redis
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/examples/metadata/components/pubsub.yaml
+++ b/examples/metadata/components/pubsub.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""

--- a/examples/metadata/components/statestore.yaml
+++ b/examples/metadata/components/statestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
+  - name: actorStateStore
+    value: "true"

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -678,6 +678,75 @@ class DaprGrpcClientTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 dapr.unlock(store_name, resource_id, invalid_input)
 
+    #
+    # Tests for Metadata API
+    #
+
+    def test_get_metadata(self):
+        with DaprGrpcClient(f'localhost:{self.server_port}') as dapr:
+            response = dapr.get_metadata()
+
+            self.assertIsNotNone(response)
+
+            self.assertEqual(response.application_id, 'myapp')
+
+            actors = response.active_actors_count
+            self.assertIsNotNone(actors)
+            self.assertTrue(len(actors) > 0)
+            for actorType, count in actors.items():
+                # Assert both are non-null and non-empty/zero
+                self.assertTrue(actorType)
+                self.assertTrue(count)
+
+            self.assertIsNotNone(response.registered_components)
+            self.assertTrue(len(response.registered_components) > 0)
+            components = {c.name: c for c in response.registered_components}
+            # common tests for all components
+            for c in components.values():
+                self.assertTrue(c.name)
+                self.assertTrue(c.type)
+                self.assertIsNotNone(c.version)
+                self.assertIsNotNone(c.capabilities)
+            self.assertTrue("ETAG" in components['statestore'].capabilities)
+
+            self.assertIsNotNone(response.extended_metadata)
+
+    def test_set_metadata(self):
+        metadata_key = "test_set_metadata_attempt"
+        with DaprGrpcClient(f'localhost:{self.server_port}') as dapr:
+            for metadata_value in [str(i) for i in range(10)]:
+                dapr.set_metadata(attributeName=metadata_key,
+                                  attributeValue=metadata_value)
+                response = dapr.get_metadata()
+                self.assertIsNotNone(response)
+                self.assertIsNotNone(response.extended_metadata)
+                self.assertEqual(response.extended_metadata[metadata_key],
+                                 metadata_value)
+            # Empty string and blank strings should be accepted just fine
+            # by this API
+            for metadata_value in ['', '    ']:
+                dapr.set_metadata(attributeName=metadata_key,
+                                  attributeValue=metadata_value)
+                response = dapr.get_metadata()
+                self.assertIsNotNone(response)
+                self.assertIsNotNone(response.extended_metadata)
+                self.assertEqual(response.extended_metadata[metadata_key],
+                                 metadata_value)
+
+    def test_set_metadata_input_validation(self):
+        dapr = DaprGrpcClient(f'localhost:{self.server_port}')
+        valid_attr_name = 'attribute name'
+        valid_attr_value = 'attribute value'
+        # Invalid inputs for string arguments
+        with DaprGrpcClient(f'localhost:{self.server_port}') as dapr:
+            for invalid_attr_name in [None, '', '   ']:
+                with self.assertRaises(ValueError):
+                    dapr.set_metadata(invalid_attr_name, valid_attr_value)
+            # We are less strict with attribute values - we just cannot accept None
+            for invalid_attr_value in [None]:
+                with self.assertRaises(ValueError):
+                    dapr.set_metadata(valid_attr_name, invalid_attr_value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
     ./validate.sh grpc_proxying
     ./validate.sh w3c-tracing
     ./validate.sh distributed_lock
+    ./validate.sh metadata
     ./validate.sh ../
 commands_pre =
     pip3 install -e {toxinidir}/


### PR DESCRIPTION
# Description

This PR adds support for [Metadata API] to the Python SDK, along with tests and a sample example code.

Two new methods were added to the python GRPC client:

1. **get_metadata**: Gets the Dapr sidecar information provided by
   the Metadata Endpoint.
2. **set_metadata**: Adds a custom label to the Dapr sidecar
   information stored by the Metadata endpoint.

It might be worth pointing out that while this PR is code-complete, the current GRPC implementation of the [Metadata API] in dapr 1.18 returns a response missing some fields. See dapr/dapr#5038 and dapr/dapr#5018. This is being tracked in #445.

[Metadata API]: https://docs.dapr.io/reference/api/metadata_api/


## Issue reference
Please reference the issue this PR will close: #410 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
