### PR TITLE
fix wrong comment in wait method

### DIFF
--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -1098,7 +1098,7 @@ class DaprGrpcClient:
             from dapr.clients import DaprClient
 
             with DaprClient() as d:
-                d.wait(1000) # waits for 1 second.
+                d.wait(1) # waits for 1 second.
                 # Sidecar is available after this.
 
         Args:


### PR DESCRIPTION
# Description

There is `d.wait(1000) # waits for 1 second` in the comment. But in fact, the incoming parameters are in seconds, so the comment should be corrected.

In this repo, the rest of the code is correctly passed in with parameters in seconds.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #448 

## Checklist

* [√] Code compiles correctly
* [√] Created/updated tests
* [√] Extended the documentation
