### PR TITLE
GRPC App run fix optional app_port

### DIFF
--- a/ext/dapr-ext-grpc/dapr/ext/grpc/app.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/app.py
@@ -54,7 +54,7 @@ class App:
         """Adds an external gRPC service to the same server"""
         servicer_callback(external_servicer, self._server)
 
-    def run(self, app_port: Optional[int]) -> None:
+    def run(self, app_port: Optional[int] = None) -> None:
         """Starts app gRPC server and waits until :class:`App`.stop() is called."""
         if app_port is None:
             app_port = settings.GRPC_APP_PORT


### PR DESCRIPTION
Signed-off-by: c-thiel

# Description

Add missing default in grpc App run method.

## Issue reference
#454

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
