### PR TITLE
Allows running workflow with specific dapr version

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -13,17 +13,26 @@ on:
       - release-*
       - feature/*
   workflow_dispatch:
+    inputs:
+      daprdapr_commit:
+        description: 'Dapr/Dapr commit to build custom daprd from'
+        required: false
+        default: ''
+      daprcli_commit:
+        description: 'Dapr/CLI commit to build custom dapr CLI from'
+        required: false
+        default: ''
 jobs:
   validate:
     runs-on: ubuntu-latest
     env:
-      GOVER: 1.18
+      GOVER: 1.19
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
-      DAPR_CLI_REF:
-      DAPR_REF: 
+      DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
+      DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This allows specifying of the dapr/dapr and dapr/cli commits to use to run the workflow.

This can either be manually run via the Actions tab, or be scripted for Dapr bot in a follow-up PR.

Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>