### PR TITLE
Adds `/ok-to-test` option for workflow validation

### DIFF
--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -20,6 +20,7 @@ jobs:
               "mukundansundar",
               "wcs1only",
               "berndverst",
+              "tmacam",
             ];
             const payload = context.payload;
             const issue = context.issue;
@@ -55,20 +56,32 @@ jobs:
               });
               return;
             }
-            // Pollyfill: register createDispatchEvent because actions/github-script@0.3.0 
-            // does not have createDispatchEvent.
-            github.registerEndpoints({
-              repos: {
-                createDispatchEvent: {
-                  "headers": { "accept": "application/vnd.github.everest-preview+json" },
-                  "method": "POST",
-                  "params": {
-                    "client_payload": { "type": "object" },
-                    "event_type": { "type": "string" },
-                    "owner": { "required": true, "type": "string" },
-                    "repo": { "required": true, "type": "string" }
-                  },
-                  "url": "/repos/:owner/:repo/dispatches"
+            if (isFromPulls && commentBody) {
+              if (commentBody.indexOf("/ok-to-test") == 0) {
+                // Get pull request
+                const pull = await github.pulls.get({
+                  owner: issue.owner,
+                  repo: issue.repo,
+                  pull_number: issue.number
+                });
+                if (pull && pull.data) {
+                  // Get commit id and repo from pull head
+                  const testPayload = {
+                    pull_head_ref: pull.data.head.sha,
+                    pull_head_repo: pull.data.head.repo.full_name,
+                    command: "ok-to-test",
+                    issue: issue,
+                  };
+                  // Fire repository_dispatch event to trigger certification test
+                  await github.repos.createDispatchEvent({
+                    owner: issue.owner,
+                    repo: issue.repo,
+                    event_type: "validate-examples",
+                    "inputs": {
+                      "daprdapr_commit": "master"
+                    },
+                    client_payload: testPayload,
+                  });
                 }
               }
-            });
+            }

--- a/.github/workflows/dapr-bot.yml
+++ b/.github/workflows/dapr-bot.yml
@@ -77,9 +77,6 @@ jobs:
                     owner: issue.owner,
                     repo: issue.repo,
                     event_type: "validate-examples",
-                    "inputs": {
-                      "daprdapr_commit": "master"
-                    },
                     client_payload: testPayload,
                   });
                 }

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -33,12 +33,28 @@ jobs:
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF: ${{ github.event.inputs.daprcli_commit }}
       DAPR_REF: ${{ github.event.inputs.daprdapr_commit }}
+      CHECKOUT_REPO: ${{ github.repository }}
+      CHECKOUT_REF: ${{ github.ref }}
+
     strategy:
       fail-fast: false
       matrix:
         python_ver: [3.7, 3.8, 3.9, "3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - name: Parse repository_dispatch payload
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          if [ ${{ github.event.client_payload.command }} = "ok-to-test" ]; then
+            echo "CHECKOUT_REPO=${{ github.event.client_payload.pull_head_repo }}" >> $GITHUB_ENV
+            echo "CHECKOUT_REF=${{ github.event.client_payload.pull_head_ref }}" >> $GITHUB_ENV
+            echo "DAPR_REF=master" >> $GITHUB_ENV
+          fi
+
+      - name: Check out code onto GOPATH
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
       - uses: azure/setup-helm@v3.3
       - name: Determine latest Dapr Runtime version
         run: |


### PR DESCRIPTION
Adds `/ok-to-test` to run example validation against latest `dapr/dapr`@master

Signed-off-by: Bernd Verst <4535280+berndverst@users.noreply.github.com>