### PR TITLE
Fix return type of resource enter protocol in DaprGrpcClient. Fixes #520

### DIFF
--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -21,6 +21,7 @@ from urllib.parse import urlencode
 from warnings import warn
 
 from typing import Dict, Optional, Union, Sequence, List
+from typing_extensions import Self
 
 from google.protobuf.message import Message as GrpcMessage
 from google.protobuf.empty_pb2 import Empty as GrpcEmpty
@@ -147,7 +148,7 @@ class DaprGrpcClient:
     def __del__(self):
         self.close()
 
-    def __enter__(self) -> 'DaprGrpcClient':
+    def __enter__(self) -> Self:  # type: ignore
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ Flask>=1.1
 mypy==0.991
 mypy-extensions>=0.4.3
 mypy-protobuf>=2.9
-flake8>=3.7.9 
+flake8>=3.7.9
 aiohttp>=3.6.2
 python-dateutil>=2.8.1
 grpcio>=1.37.0
@@ -16,3 +16,4 @@ coverage>=5.3
 codecov>=1.4.0
 httpx==0.23.1
 wheel
+typing-extensions>=4.4.0


### PR DESCRIPTION
# Description

Fixes return type of `DaprGrpcClient` so that sub-classes i.e `DaprClient` gets the right type back when doing `with DaprClient as d`.

Note that mypy does not currently handle the `Self` type https://github.com/python/mypy/issues/14089 so we need a new version of mypy for this to work. Current version of mypy gives: `Variable "typing_extensions.Self" is not valid as a type  [valid-type]`. To make it work I've added `# type: ignore` on the line which seems to work with both current version of mypy and sub-classes gets the right type with type checkers such as pyright.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #520 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (not needed)
* [ ] Extended the documentation (not needed)
