### PR TITLE
Fix wrong key typing in get_configuration issue #491

### DIFF
--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -906,7 +906,7 @@ class DaprGrpcClient:
     def get_configuration(
             self,
             store_name: str,
-            keys: str,
+            keys: List[str],
             config_metadata: Optional[Dict[str, str]] = dict()) -> ConfigurationResponse:
         """Gets value from a config store with a key
 


### PR DESCRIPTION
# Description

This PR fixes the wrong key typing in get_configuration. str -> list[str]

## Issue reference

This PR will close: #491 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
