### PR TITLE
PubSub over gRPC: extracts custom data as cloud event `extensions`, adds topic as cloud event `subject` as per spec

### DIFF
--- a/examples/pubsub-simple/README.md
+++ b/examples/pubsub-simple/README.md
@@ -35,6 +35,7 @@ expected_stdout_lines:
   - '== APP == Wildcard-Subscriber received: id=5, message="hello world", content_type="application/json"'
   - '== APP == Wildcard-Subscriber received: id=6, message="hello world", content_type="application/json"'
   - '== APP == Dead-Letter Subscriber received: id=7, message="hello world", content_type="application/json"'
+  - '== APP == Dead-Letter Subscriber. Received via deadletter topic: TOPIC_D_DEAD'
   - '== APP == Dead-Letter Subscriber. Originally intended topic: TOPIC_D'
 output_match_mode: substring
 background: true

--- a/examples/pubsub-simple/README.md
+++ b/examples/pubsub-simple/README.md
@@ -35,6 +35,7 @@ expected_stdout_lines:
   - '== APP == Wildcard-Subscriber received: id=5, message="hello world", content_type="application/json"'
   - '== APP == Wildcard-Subscriber received: id=6, message="hello world", content_type="application/json"'
   - '== APP == Dead-Letter Subscriber received: id=7, message="hello world", content_type="application/json"'
+  - '== APP == Dead-Letter Subscriber. Originally intended topic: TOPIC_D'
 output_match_mode: substring
 background: true
 match_order: none

--- a/examples/pubsub-simple/publisher.py
+++ b/examples/pubsub-simple/publisher.py
@@ -67,6 +67,7 @@ with DaprClient() as d:
         topic_name='TOPIC_D',
         data=json.dumps(req_data),
         data_content_type='application/json',
+        publish_metadata={'custommeta': 'somevalue'}
     )
 
     # Print the request

--- a/examples/pubsub-simple/subscriber.py
+++ b/examples/pubsub-simple/subscriber.py
@@ -29,6 +29,7 @@ def mytopic(event: v1.Event) -> TopicEventResponse:
     data = json.loads(event.Data())
     print(f'Subscriber received: id={data["id"]}, message="{data["message"]}", '
           f'content_type="{event.content_type}"', flush=True)
+    # event.Metadata() contains a dictionary of cloud event extensions and publish metadata
     if should_retry:
         should_retry = False  # we only retry once in this example
         sleep(0.5)  # add some delay to help with ordering of expected logs
@@ -46,7 +47,9 @@ def mytopic_dead(event: v1.Event) -> TopicEventResponse:
     data = json.loads(event.Data())
     print(f'Dead-Letter Subscriber received: id={data["id"]}, message="{data["message"]}", '
           f'content_type="{event.content_type}"', flush=True)
+    print("Dead-Letter Subscriber. Originally intended topic: " + event.Subject(), flush=True)
     return TopicEventResponse('success')
+
 
 # == for testing with Redis only ==
 # workaround as redis pubsub does not support wildcards

--- a/examples/pubsub-simple/subscriber.py
+++ b/examples/pubsub-simple/subscriber.py
@@ -47,7 +47,9 @@ def mytopic_dead(event: v1.Event) -> TopicEventResponse:
     data = json.loads(event.Data())
     print(f'Dead-Letter Subscriber received: id={data["id"]}, message="{data["message"]}", '
           f'content_type="{event.content_type}"', flush=True)
-    print("Dead-Letter Subscriber. Originally intended topic: " + event.Subject(), flush=True)
+    print("Dead-Letter Subscriber. Received via deadletter topic: " + event.Subject(), flush=True)
+    print("Dead-Letter Subscriber. Originally intended topic: " + event.Extensions()['topic'],
+          flush=True)
     return TopicEventResponse('success')
 
 


### PR DESCRIPTION
Signed-off-by: Bernd Verst <github@bernd.dev>

Fixes #437 - now cloud event Subject is the Topic (`event.Subject()`)
Fixes #405 - now all cloud event extensions (custom fields in the payload) will be sent (`event.Extensions()`)