### PR TITLE
fix github workflow

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -120,8 +120,9 @@ jobs:
         if: env.DAPR_REF != ''
         run: |
           docker stop dapr_placement
-          cd dapr
+          cd dapr_runtime
           ./dist/linux_amd64/release/placement --healthz-port 9091 &
+          cd ..
       - name: Check Examples
         run: |
           tox -e examples


### PR DESCRIPTION
Signed-off-by: Bernd Verst <github@bernd.dev>

# Description

Fixes the validate examples workflow for `/ok-to-test` use