### PR TITLE
Define SDK dependency on typing-extensions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     grpcio >= 1.37.0
     aiohttp >= 3.6.2
     python-dateutil >= 2.8.1
+    typing-extensions>=4.4.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
# Description

PR #521 added an implicit dependency on `typing-extensions`. During development this dependency is satisfied as it is mentioned on `dev-requirements.txt`. However, new instalations of the Python SDK will not bring this pendency and applications depending on `dapr.client.DaprClient` will fail to load with an import exception.

This PR addresses this by adding `typing-extensions` to the dependency list of the generated python sdk package.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #544 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
