### PR TITLE
Remove unnecessary dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,19 +1,11 @@
-Flask>=1.1
 mypy==1.2.0
 mypy-extensions>=0.4.3
 mypy-protobuf>=2.9
 flake8>=3.7.9
-aiohttp>=3.6.2
-python-dateutil>=2.8.1
-grpcio>=1.37.0
-protobuf>=3.17.3,<4.22
-six==1.16.0
 tox>=4.3.0
-cloudevents>=1.0.0
-opencensus>=0.11.0
-opencensus-ext-grpc>=0.7.0
 coverage>=5.3
 codecov>=1.4.0
-httpx==0.24.0
 wheel
-typing-extensions>=4.4.0
+# used in unit test only
+opencensus>=0.11.0
+httpx==0.24.0


### PR DESCRIPTION
# Description

Addresses #546

`dev-requirements.txt` should only contain dependencies not covered by `setup.cfg` - and only dependencies required in unit tests, or tools to run tests, generate protos etc.