### PR TITLE
subscribe method updated

### DIFF
--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -21,7 +21,7 @@ from urllib.parse import urlencode
 
 from warnings import warn
 
-from typing import Dict, Optional, Union, Sequence, List
+from typing import Callable, Dict, Optional, Text, Union, Sequence, List
 from typing_extensions import Self
 
 from google.protobuf.message import Message as GrpcMessage
@@ -962,7 +962,8 @@ class DaprGrpcClientAsync:
             self,
             store_name: str,
             keys: List[str],
-            config_metadata: Optional[Dict[str, str]] = dict()) -> ConfigurationWatcher:
+            config_metadata: Optional[Dict[str, str]] = dict(),
+            handler: Callable[[Text,ConfigurationResponse], None] = None) -> Text:
         """Gets changed value from a config store with a key
 
         The example gets value from a config store:
@@ -989,13 +990,13 @@ class DaprGrpcClientAsync:
         if not store_name or len(store_name) == 0 or len(store_name.strip()) == 0:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
-        configWatcher.watch_configuration(self._stub, store_name, keys, config_metadata)
-        return configWatcher
+        id = configWatcher.watch_configuration(self._stub, store_name, keys, config_metadata, handler)
+        return id
 
     async def unsubscribe_configuration(
             self,
             store_name: str,
-            key: str) -> bool:
+            id: str) -> bool:
         """Unsubscribes from configuration changes.
 
             Args:
@@ -1007,8 +1008,7 @@ class DaprGrpcClientAsync:
         """
         warn('The Unsubscribe Configuration API is an Alpha version and is subject to change.',
              UserWarning, stacklevel=2)
-        req = api_v1.UnsubscribeConfigurationRequest(store_name=store_name, id=key)
-        self._stub.UnsubscribeConfigurationAlpha1(req)
+        req = api_v1.UnsubscribeConfigurationRequest(store_name=store_name, id=id)
         call = self._stub.UnsubscribeConfigurationAlpha1(req)
         response: UnsubscribeConfigurationResponse = await call
         return response.ok

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -972,17 +972,18 @@ class DaprGrpcClientAsync:
                 resp = await d.subscribe_config(
                     store_name='state_store'
                     key='key_1',
+                    handler=handler,
                     config_metadata={"metakey": "metavalue"}
                 )
 
         Args:
             store_name (str): the state store name to get from
             keys (str array): the keys of the key-value pairs to be gotten
+            handler(func (key, ConfigurationResponse)): the handler to be called when the config changes
             config_metadata (Dict[str, str], optional): Dapr metadata for configuration
 
         Returns:
-            :class:`ConfigurationResponse` gRPC metadata returned from callee
-            and value obtained from the config store
+            id (str): subscription id, which can be used to unsubscribe later
         """
         warn('The Subscribe Configuration API is an Alpha version and is subject to change.',
              UserWarning, stacklevel=2)
@@ -1002,7 +1003,7 @@ class DaprGrpcClientAsync:
 
             Args:
                 store_name (str): the state store name to unsubscribe from
-                key (str): the key of the key-value pair to unsubscribe from
+                id (str): the subscription id to unsubscribe
 
             Returns:
                 bool: True if unsubscribed successfully, False otherwise

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -963,7 +963,7 @@ class DaprGrpcClientAsync:
             store_name: str,
             keys: List[str],
             config_metadata: Optional[Dict[str, str]] = dict(),
-            handler: Callable[[Text,ConfigurationResponse], None] = None) -> Text:
+            handler: Callable[[Text, ConfigurationResponse], None] = None) -> Text:
         """Gets changed value from a config store with a key
 
         The example gets value from a config store:
@@ -990,7 +990,8 @@ class DaprGrpcClientAsync:
         if not store_name or len(store_name) == 0 or len(store_name.strip()) == 0:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
-        id = configWatcher.watch_configuration(self._stub, store_name, keys, config_metadata, handler)
+        id = configWatcher.watch_configuration(self._stub, store_name, keys, 
+                                               config_metadata, handler)
         return id
 
     async def unsubscribe_configuration(

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -962,8 +962,8 @@ class DaprGrpcClientAsync:
             self,
             store_name: str,
             keys: List[str],
-            config_metadata: Optional[Dict[str, str]] = dict(),
-            handler: Callable[[Text, ConfigurationResponse], None] = None) -> Text:
+            handler: Callable[[Text, ConfigurationResponse], None],
+            config_metadata: Optional[Dict[str, str]] = dict()) -> Text:
         """Gets changed value from a config store with a key
 
         The example gets value from a config store:
@@ -991,7 +991,7 @@ class DaprGrpcClientAsync:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
         id = configWatcher.watch_configuration(self._stub, store_name, keys,
-                                               config_metadata, handler)
+                                               handler, config_metadata)
         return id
 
     async def unsubscribe_configuration(

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -979,7 +979,7 @@ class DaprGrpcClientAsync:
         Args:
             store_name (str): the state store name to get from
             keys (str array): the keys of the key-value pairs to be gotten
-            handler(func (key, ConfigurationResponse)): the handler to be called when the config changes
+            handler(func (key, ConfigurationResponse)): the callback function to be called
             config_metadata (Dict[str, str], optional): Dapr metadata for configuration
 
         Returns:

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -990,7 +990,7 @@ class DaprGrpcClientAsync:
         if not store_name or len(store_name) == 0 or len(store_name.strip()) == 0:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
-        id = configWatcher.watch_configuration(self._stub, store_name, keys, 
+        id = configWatcher.watch_configuration(self._stub, store_name, keys,
                                                config_metadata, handler)
         return id
 

--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -686,8 +686,8 @@ class ConfigurationWatcher():
         self.id: str = ""
 
     def watch_configuration(self, stub: api_service_v1.DaprStub, store_name: str,
-                            keys: List[str], config_metadata: Optional[Dict[str, str]] = dict(),
-                            handler: Callable[[Text, ConfigurationResponse], None] = None):
+                            keys: List[str], handler: Callable[[Text, ConfigurationResponse], None],
+                            config_metadata: Optional[Dict[str, str]] = dict()):
         req = api_v1.SubscribeConfigurationRequest(
             store_name=store_name, keys=keys, metadata=config_metadata)
         thread = threading.Thread(target=self._read_subscribe_config, args=(stub, req, handler))
@@ -703,7 +703,7 @@ class ConfigurationWatcher():
 
     def _read_subscribe_config(self, stub: api_service_v1.DaprStub,
                                req: api_v1.SubscribeConfigurationRequest,
-                               handler: Callable[[Text, ConfigurationResponse], None] = None):
+                               handler: Callable[[Text, ConfigurationResponse], None]):
         try:
             responses = stub.SubscribeConfigurationAlpha1(req)
             isFirst = True

--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 import contextlib
 import threading
 from enum import Enum
-from typing import Callable, Dict, Optional, Text, Union, Sequence, List, Mapping, TYPE_CHECKING, NamedTuple
+from typing import ( 
+    Callable, Dict, List, Optional, Text, Union, 
+    Sequence, Mapping, TYPE_CHECKING, NamedTuple
+)
 
 from google.protobuf.any_pb2 import Any as GrpcAny
 from google.protobuf.message import Message as GrpcMessage
@@ -680,11 +683,11 @@ class ConfigurationResponse(DaprResponse):
 class ConfigurationWatcher():
     def __init__(self):
         self.event: threading.Event = threading.Event()
-        self.id : str = ""
+        self.id: str = ""
 
     def watch_configuration(self, stub: api_service_v1.DaprStub, store_name: str,
                             keys: List[str], config_metadata: Optional[Dict[str, str]] = dict(),
-                            handler: Callable[[Text,ConfigurationResponse], None] = None):
+                            handler: Callable[[Text, ConfigurationResponse], None] = None):
         req = api_v1.SubscribeConfigurationRequest(
             store_name=store_name, keys=keys, metadata=config_metadata)
         thread = threading.Thread(target=self._read_subscribe_config, args=(stub, req, handler))
@@ -700,7 +703,7 @@ class ConfigurationWatcher():
 
     def _read_subscribe_config(self, stub: api_service_v1.DaprStub,
                                req: api_v1.SubscribeConfigurationRequest,
-                               handler: Callable[[Text,ConfigurationResponse], None] = None):
+                               handler: Callable[[Text, ConfigurationResponse], None] = None):
         try:
             responses = stub.SubscribeConfigurationAlpha1(req)
             isFirst = True
@@ -710,7 +713,7 @@ class ConfigurationWatcher():
                     self.event.set()
                     isFirst = False
                 if len(response.items) > 0:
-                    handler(response.id,ConfigurationResponse(response.items))
+                    handler(response.id, ConfigurationResponse(response.items))
         except Exception:
             print(f"{self.store_name} configuration watcher for keys "
                   f"{self.keys} stopped.")

--- a/dapr/clients/grpc/_response.py
+++ b/dapr/clients/grpc/_response.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 import contextlib
 import threading
 from enum import Enum
-from typing import ( 
-    Callable, Dict, List, Optional, Text, Union, 
+from typing import (
+    Callable, Dict, List, Optional, Text, Union,
     Sequence, Mapping, TYPE_CHECKING, NamedTuple
 )
 

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -963,7 +963,7 @@ class DaprGrpcClient:
         Args:
             store_name (str): the state store name to get from
             keys (str array): the keys of the key-value pairs to be gotten
-            handler(func (key, ConfigurationResponse)): the handler to be called when the config changes
+            handler(func (key, ConfigurationResponse)): the callback function to be called
             config_metadata (Dict[str, str], optional): Dapr metadata for configuration
 
         Returns:

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -946,8 +946,8 @@ class DaprGrpcClient:
             self,
             store_name: str,
             keys: List[str],
-            config_metadata: Optional[Dict[str, str]] = dict(),
-            handler: Callable[[Text, ConfigurationResponse], None] = None) -> Text:
+            handler: Callable[[Text, ConfigurationResponse], None],
+            config_metadata: Optional[Dict[str, str]] = dict()) -> Text:
         """Gets changed value from a config store with a key
 
         The example gets value from a config store:
@@ -975,7 +975,7 @@ class DaprGrpcClient:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
         id = configWatcher.watch_configuration(self._stub, store_name, keys,
-                                               config_metadata, handler)
+                                               handler, config_metadata)
         return id
 
     def unsubscribe_configuration(

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -947,7 +947,7 @@ class DaprGrpcClient:
             store_name: str,
             keys: List[str],
             config_metadata: Optional[Dict[str, str]] = dict(),
-            handler: Callable[[Text,ConfigurationResponse], None] = None) -> Text:
+            handler: Callable[[Text, ConfigurationResponse], None] = None) -> Text:
         """Gets changed value from a config store with a key
 
         The example gets value from a config store:
@@ -974,7 +974,8 @@ class DaprGrpcClient:
         if not store_name or len(store_name) == 0 or len(store_name.strip()) == 0:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
-        id = configWatcher.watch_configuration(self._stub, store_name, keys, config_metadata, handler)
+        id = configWatcher.watch_configuration(self._stub, store_name, keys, 
+                                               config_metadata, handler)
         return id
 
     def unsubscribe_configuration(

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -974,7 +974,7 @@ class DaprGrpcClient:
         if not store_name or len(store_name) == 0 or len(store_name.strip()) == 0:
             raise ValueError("Config store name cannot be empty to get the configuration")
         configWatcher = ConfigurationWatcher()
-        id = configWatcher.watch_configuration(self._stub, store_name, keys, 
+        id = configWatcher.watch_configuration(self._stub, store_name, keys,
                                                config_metadata, handler)
         return id
 

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -956,17 +956,18 @@ class DaprGrpcClient:
                 resp = d.subscribe_config(
                     store_name='state_store'
                     key='key_1',
+                    handler=handler,
                     config_metadata={"metakey": "metavalue"}
                 )
 
         Args:
             store_name (str): the state store name to get from
             keys (str array): the keys of the key-value pairs to be gotten
+            handler(func (key, ConfigurationResponse)): the handler to be called when the config changes
             config_metadata (Dict[str, str], optional): Dapr metadata for configuration
 
         Returns:
-            :class:`ConfigurationResponse` gRPC metadata returned from callee
-            and value obtained from the config store
+            id (str): subscription id, which can be used to unsubscribe later
         """
         warn('The Subscribe Configuration API is an Alpha version and is subject to change.',
              UserWarning, stacklevel=2)
@@ -986,7 +987,7 @@ class DaprGrpcClient:
 
             Args:
                 store_name (str): the state store name to unsubscribe from
-                key (str): the key of the key-value pair to unsubscribe from
+                id (str): the subscription id to unsubscribe
 
             Returns:
                 bool: True if unsubscribed successfully, False otherwise

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -51,7 +51,6 @@ expected_stdout_lines:
   - "== APP == Got key=orderId2 value=200 version=1 metadata={}"
   - "== APP == Subscribe key=orderId2 value=210 version=2 metadata={}"
   - "== APP == Unsubscribed successfully? True"
-  - "== APP == configurationstore configuration watcher for keys ['orderId1', 'orderId2'] stopped."
 background: true
 timeout_seconds: 30
 sleep: 3

--- a/examples/configuration/configuration.py
+++ b/examples/configuration/configuration.py
@@ -36,7 +36,7 @@ async def executeConfiguration():
 
         # Subscribe to configuration for keys {orderId1,orderId2}.
         id = d.subscribe_configuration(store_name=storeName, keys=keys,
-                                    config_metadata={}, handler=handler)
+                                       handler=handler, config_metadata={})
         print("Subscription ID is", id, flush=True)
         sleep(10)
 

--- a/examples/configuration/configuration.py
+++ b/examples/configuration/configuration.py
@@ -4,17 +4,9 @@ dapr run --app-id configexample --components-path components/ -- python3 configu
 
 import asyncio
 from time import sleep
-# from dapr.clients import DaprClient
-# from dapr.clients.grpc._response import ConfigurationWatcher
-import sys
-sys.path.insert(0,'/Users/shivamkumar/codes/dapr/python-sdk/')
-# sys.path.insert(0,'/Users/shivamkumar/codes/dapr/python-sdk/dapr/clients/grpc')
-for p in sys.path:
-    print(p)
-# from base import DaprActorClientBase
-# import DaprClient
 from dapr.clients import DaprClient
-from dapr.clients.grpc._response import ConfigurationWatcher,ConfigurationResponse
+from dapr.clients.grpc._response import ConfigurationWatcher, ConfigurationResponse
+
 configuration: ConfigurationWatcher = ConfigurationWatcher()
 
 def handler(id: str, resp: ConfigurationResponse):

--- a/examples/configuration/configuration.py
+++ b/examples/configuration/configuration.py
@@ -4,11 +4,23 @@ dapr run --app-id configexample --components-path components/ -- python3 configu
 
 import asyncio
 from time import sleep
+# from dapr.clients import DaprClient
+# from dapr.clients.grpc._response import ConfigurationWatcher
+import sys
+sys.path.insert(0,'/Users/shivamkumar/codes/dapr/python-sdk/')
+# sys.path.insert(0,'/Users/shivamkumar/codes/dapr/python-sdk/dapr/clients/grpc')
+for p in sys.path:
+    print(p)
+# from base import DaprActorClientBase
+# import DaprClient
 from dapr.clients import DaprClient
-from dapr.clients.grpc._response import ConfigurationWatcher
-
+from dapr.clients.grpc._response import ConfigurationWatcher,ConfigurationResponse
 configuration: ConfigurationWatcher = ConfigurationWatcher()
 
+def handler(id: str, resp: ConfigurationResponse):
+    print("Got configuration update", flush=True)
+    print("id: ", id, flush=True)
+    print("items: ", resp.items, flush=True)
 
 async def executeConfiguration():
     with DaprClient() as d:
@@ -29,23 +41,14 @@ async def executeConfiguration():
                   f"version={configuration.items[key].version} "
                   f"metadata={configuration.items[key].metadata}", flush=True)
 
-        # Subscribe to configuration by key.
-        configuration = await d.subscribe_configuration(store_name=storeName, keys=keys,
-                                                        config_metadata={})
-        for x in range(5):
-            if configuration is not None:
-                print("Got configuration update", flush=True)
-                items = configuration.get_items()
-                for key in items:
-                    print(f"Subscribe key={key} value={items[key].value} "
-                          f"version={items[key].version} "
-                          f"metadata={items[key].metadata}", flush=True)
-            else:
-                print("Nothing yet")
-            sleep(3)
+        # Subscribe to configuration for keys {orderId1,orderId2}.
+        id = d.subscribe_configuration(store_name=storeName, keys=keys,
+                                                        config_metadata={},handler=handler)
+        print("Subscription ID is", id, flush=True)
+        sleep(10)
 
         # Unsubscribe from configuration
-        isSuccess = d.unsubscribe_configuration(store_name=storeName, key=keys[1])
+        isSuccess = d.unsubscribe_configuration(store_name=storeName, id=id)
         print(f"Unsubscribed successfully? {isSuccess}", flush=True)
 
 asyncio.run(executeConfiguration())

--- a/examples/configuration/configuration.py
+++ b/examples/configuration/configuration.py
@@ -10,9 +10,10 @@ from dapr.clients.grpc._response import ConfigurationWatcher, ConfigurationRespo
 configuration: ConfigurationWatcher = ConfigurationWatcher()
 
 def handler(id: str, resp: ConfigurationResponse):
-    print("Got configuration update", flush=True)
-    print("id: ", id, flush=True)
-    print("items: ", resp.items, flush=True)
+    for key in resp.items:
+        print(f"Subscribe key={key} value={resp.items[key].value} "
+              f"version={resp.items[key].version} "
+              f"metadata={resp.items[key].metadata}", flush=True)
 
 async def executeConfiguration():
     with DaprClient() as d:
@@ -35,7 +36,7 @@ async def executeConfiguration():
 
         # Subscribe to configuration for keys {orderId1,orderId2}.
         id = d.subscribe_configuration(store_name=storeName, keys=keys,
-                                                        config_metadata={},handler=handler)
+                                    config_metadata={}, handler=handler)
         print("Subscription ID is", id, flush=True)
         sleep(10)
 

--- a/tests/clients/test_dapr_async_grpc_client.py
+++ b/tests/clients/test_dapr_async_grpc_client.py
@@ -489,15 +489,15 @@ class DaprGrpcClientAsyncTests(unittest.IsolatedAsyncioTestCase):
     async def test_subscribe_configuration(self):
         dapr = DaprGrpcClientAsync(f'localhost:{self.server_port}')
 
-        def mock_watch(self, stub, store_name, keys, config_metadata,handler):
+        def mock_watch(self, stub, store_name, keys, config_metadata, handler):
             handler("id", ConfigurationResponse(items={
                 "k": ConfigurationItem(
                     value="test",
                     version="1.7.0")
             }))
             return "id"
-        
-        def handler(id:str, resp:ConfigurationResponse):
+
+        def handler(id: str, resp: ConfigurationResponse):
             self.assertEqual(resp.items["k"].value, "test")
             self.assertEqual(resp.items["k"].version, "1.7.0")
 

--- a/tests/clients/test_dapr_async_grpc_client.py
+++ b/tests/clients/test_dapr_async_grpc_client.py
@@ -489,7 +489,7 @@ class DaprGrpcClientAsyncTests(unittest.IsolatedAsyncioTestCase):
     async def test_subscribe_configuration(self):
         dapr = DaprGrpcClientAsync(f'localhost:{self.server_port}')
 
-        def mock_watch(self, stub, store_name, keys, config_metadata, handler):
+        def mock_watch(self, stub, store_name, keys, handler, config_metadata):
             handler("id", ConfigurationResponse(items={
                 "k": ConfigurationItem(
                     value="test",

--- a/tests/clients/test_dapr_async_grpc_client.py
+++ b/tests/clients/test_dapr_async_grpc_client.py
@@ -32,6 +32,7 @@ from dapr.clients.grpc._state import StateOptions, Consistency, Concurrency, Sta
 from dapr.clients.grpc._response import (
     ConfigurationItem,
     ConfigurationWatcher,
+    ConfigurationResponse,
     UnlockResponseStatus,
 )
 
@@ -488,22 +489,25 @@ class DaprGrpcClientAsyncTests(unittest.IsolatedAsyncioTestCase):
     async def test_subscribe_configuration(self):
         dapr = DaprGrpcClientAsync(f'localhost:{self.server_port}')
 
-        def mock_watch(self, stub, store_name, keys, config_metadata):
-            self.items[keys[0]] = ConfigurationItem(
-                value="test",
-                version="1.7.0")
+        def mock_watch(self, stub, store_name, keys, config_metadata,handler):
+            handler("id", ConfigurationResponse(items={
+                "k": ConfigurationItem(
+                    value="test",
+                    version="1.7.0")
+            }))
+            return "id"
+        
+        def handler(id:str, resp:ConfigurationResponse):
+            self.assertEqual(resp.items["k"].value, "test")
+            self.assertEqual(resp.items["k"].version, "1.7.0")
 
         with patch.object(ConfigurationWatcher, 'watch_configuration', mock_watch):
-            watcher = await dapr.subscribe_configuration(
-                store_name="configurationstore", keys=["k"])
-            resp = watcher.get_items()
-            self.assertIn("k", resp)
-            self.assertEqual(resp["k"].value, "test")
-            self.assertEqual(resp["k"].version, "1.7.0")
+            await dapr.subscribe_configuration(
+                store_name="configurationstore", keys=["k"], handler=handler)
 
     async def test_unsubscribe_configuration(self):
         dapr = DaprGrpcClientAsync(f'localhost:{self.server_port}')
-        res = await dapr.unsubscribe_configuration(store_name="configurationstore", key="k")
+        res = await dapr.unsubscribe_configuration(store_name="configurationstore", id="k")
         self.assertTrue(res)
 
     async def test_query_state(self):

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -499,7 +499,8 @@ class DaprGrpcClientTests(unittest.TestCase):
             self.assertEqual(resp.items["k"].version, "1.7.0")
 
         with patch.object(ConfigurationWatcher, 'watch_configuration', mock_watch):
-            _ = dapr.subscribe_configuration(store_name="configurationstore", keys=["k"], handler=handler)
+            dapr.subscribe_configuration(store_name="configurationstore",
+                                         keys=["k"], handler=handler)
 
     def test_unsubscribe_configuration(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -486,7 +486,7 @@ class DaprGrpcClientTests(unittest.TestCase):
     def test_subscribe_configuration(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')
 
-        def mock_watch(self, stub, store_name, keys, config_metadata, handler):
+        def mock_watch(self, stub, store_name, keys, handler, config_metadata):
             handler("id", ConfigurationResponse(items={
                 "k": ConfigurationItem(
                     value="test",

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -111,7 +111,6 @@ class DaprGrpcClientTests(unittest.TestCase):
         dapr.invocation_client = None  # force to use grpc client
 
         with self.assertRaises(NotImplementedError):
-            import asyncio
             loop = asyncio.new_event_loop()
             loop.run_until_complete(
                 dapr.invoke_method_async(
@@ -487,7 +486,7 @@ class DaprGrpcClientTests(unittest.TestCase):
     def test_subscribe_configuration(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')
 
-        def mock_watch(self, stub, store_name, keys, config_metadata,handler):
+        def mock_watch(self, stub, store_name, keys, config_metadata, handler):
             handler("id", ConfigurationResponse(items={
                 "k": ConfigurationItem(
                     value="test",
@@ -495,12 +494,12 @@ class DaprGrpcClientTests(unittest.TestCase):
             }))
             return "id"
 
-        def handler(id:str, resp:ConfigurationResponse):
+        def handler(id: str, resp: ConfigurationResponse):
             self.assertEqual(resp.items["k"].value, "test")
             self.assertEqual(resp.items["k"].version, "1.7.0")
 
         with patch.object(ConfigurationWatcher, 'watch_configuration', mock_watch):
-            _ = dapr.subscribe_configuration(store_name="configurationstore", keys=["k"],handler=handler)
+            _ = dapr.subscribe_configuration(store_name="configurationstore", keys=["k"], handler=handler)
 
     def test_unsubscribe_configuration(self):
         dapr = DaprGrpcClient(f'localhost:{self.server_port}')


### PR DESCRIPTION
# Description

The PR updates the subscribe method so that it takes a handler as an argument which will be executed whenever there is an update notification. Also the subscribe call returns ID in it's response as specified in sdk-spec(https://github.com/dapr/sig-sdk-spec/blob/main/spec/alpha/configuration.md). It updates the unsubscribe method to unsubscribe using ID, instead of a key. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #488 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
