### PR TITLE
Release Python SDK `1.10.0` (Workflow Authoring `0.1.0`)

### DIFF
--- a/dapr/version/version.py
+++ b/dapr/version/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.10.0rc1"
+__version__ = "1.10.0"

--- a/examples/demo_actor/demo_actor/requirements.txt
+++ b/examples/demo_actor/demo_actor/requirements.txt
@@ -1,1 +1,1 @@
-dapr-ext-fastapi>=1.10.0rc1
+dapr-ext-fastapi>=1.10.0

--- a/examples/invoke-simple/requirements.txt
+++ b/examples/invoke-simple/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-grpc >= 1.10.0rc1
-dapr >= 1.10.0rc1
+dapr-ext-grpc >= 1.10.0
+dapr >= 1.10.0

--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -1,5 +1,5 @@
-dapr-ext-grpc >= 1.10.0rc1
-dapr >= 1.10.0rc1
+dapr-ext-grpc >= 1.10.0
+dapr >= 1.10.0
 opencensus == 0.9.0
 opencensus-ext-grpc == 0.7.2
 opencensus-ext-zipkin == 0.2.2

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.10.0rc1"
+__version__ = "1.10.0"

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.10.0rc1
+    dapr >= 1.10.0
     uvicorn >= 0.11.6
     fastapi >= 0.60.1
 

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.10.0rc1"
+__version__ = "1.10.0"

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.10.0rc1
+    dapr >= 1.10.0
     cloudevents >= 1.0.0
 
 [options.packages.find]

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0"

--- a/ext/dapr-ext-workflow/setup.cfg
+++ b/ext/dapr-ext-workflow/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.7
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.10.0rc1
+    dapr >= 1.10.0
     durabletask >= 0.1.0a2
 
 [options.packages.find]

--- a/ext/flask_dapr/flask_dapr/version.py
+++ b/ext/flask_dapr/flask_dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.10.0rc1"
+__version__ = "1.10.0"

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -25,4 +25,4 @@ include_package_data = true
 zip_safe = false
 install_requires =
     Flask >= 1.1
-    dapr >= 1.10.0rc1
+    dapr >= 1.10.0


### PR DESCRIPTION
Release the Python SDK 1.10.0 and Workflow Authoring 0.1.0

```bash
export OLD="1\.10\.0rc1" && export NEW="1\.10\.0" && \
grep -rol "$OLD" . --include "version.py" --include "setup.cfg" --include "requirements.txt" --exclude-dir ".tox" | \
xargs sed -i '' "s/$OLD/$NEW/g"
export OLD="0\.1\.0rc1" && export NEW="0\.1\.0" && \
grep -rol "$OLD" . --include "version.py" --include "setup.cfg" --include "requirements.txt" --exclude-dir ".tox" | \
xargs sed -i '' "s/$OLD/$NEW/g"
```