### PR TITLE
Fixed: do not expect content-length header

### DIFF
--- a/tests/clients/fake_http_server.py
+++ b/tests/clients/fake_http_server.py
@@ -16,10 +16,7 @@ class DaprHandler(BaseHTTPRequestHandler):
             time.sleep(self.server.sleep_time)
         self.received_verb = verb
         self.server.request_headers = self.headers
-        if 'Content-Length' in self.headers:
-            content_length = int(self.headers['Content-Length'])
-
-            self.server.request_body += self.rfile.read(content_length)
+        self.server.request_body = self.rfile.read()
 
         self.send_response(self.server.response_code)
         for key, value in self.server.response_header_list:


### PR DESCRIPTION
The HTTP service in multiple places expected a Content-Length header or it would refuse to parse the body.

This breaks streaming (see [test failures](https://github.com/dapr/dapr/actions/runs/5446419269/jobs/9907126825)), since in case the data is streamed it's not possible to know the content's byte length in advance. The Content-Length header is not required per the HTTP specs, so we should not enforce its presence.

This fixes the issue by not relying on the Content-Length header's presence.