### PR TITLE
fix: link to dapr workflow example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ These examples demonstrate how to use the Dapr Python SDK:
 | [Secrets](./secret_store) | Get secrets from a defined secret store
 | [Distributed tracing](./w3c-tracing) | Leverage Dapr's built-in tracing support
 | [Distributed lock](./distributed_lock) | Keep your application safe from race conditions by using distributed locks
-| [Workflow](./workflow) | Run a workflow to simulate an order processor
+| [Workflow](./demo_workflow) | Run a workflow to simulate an order processor
 
 ## More information
 


### PR DESCRIPTION
# Description

This fixes a broken reference to the Dapr workflow example on the Python SDK
