### PR TITLE
[docs] Add cascading metadata

### DIFF
--- a/daprdocs/content/en/python-sdk-docs/_index.md
+++ b/daprdocs/content/en/python-sdk-docs/_index.md
@@ -5,6 +5,11 @@ linkTitle: "Python"
 weight: 1000
 description: Python SDK packages for developing Dapr applications
 no_list: true
+cascade:
+  github_repo: https://github.com/dapr/python-sdk
+  github_subdir: daprdocs/content/en/python-sdk-docs
+  path_base_for_github_subdir: content/en/developing-applications/sdks/python/
+  github_branch: master
 ---
 
 Dapr offers a variety of packages to help with the development of Python applications. Using them you can create Python clients, servers, and virtual actors with Dapr.


### PR DESCRIPTION
# Description

Adds cascading metadata so the GitHub links on the docs site work as expected

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Partially fixes https://github.com/dapr/docs/issues/1895

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
