### PR TITLE
Changing error message in wf test to match runtime

### DIFF
--- a/examples/demo_workflow/app.py
+++ b/examples/demo_workflow/app.py
@@ -27,7 +27,7 @@ workflowOptions = dict()
 workflowOptions["task_queue"] =  "testQueue"
 eventName = "event1"
 eventData = "eventData"
-nonExistentIDError = "No such instance exists"
+nonExistentIDError = "no such instance exists"
 
 def hello_world_wf(ctx: DaprWorkflowContext, input):
     print(f'{input}')


### PR DESCRIPTION
# Description

Recently the capitalization of an error message changed in dapr/dapr for workflow when GET was called on a non-existent ID. This PR changed the error message that we are comparing against in the workflow test to match the actual error message from dapr/dapr.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
