### PR TITLE
[docs] remove unnecessary shortcode

### DIFF
--- a/daprdocs/content/en/python-sdk-docs/_index.md
+++ b/daprdocs/content/en/python-sdk-docs/_index.md
@@ -36,7 +36,6 @@ pip install dapr
 {{% codetab %}}
 <!--dev-->
 > **Note:** The development package will contain features and behavior that will be compatible with the pre-release version of the Dapr runtime. Make sure to uninstall any stable versions of the Python SDK before installing the dapr-dev package.
-{{% /alert %}}
 
 ```bash
 pip install dapr-dev


### PR DESCRIPTION
# Description

Python docs are breaking when pulled into dapr/docs repo due to leftover shortcode

## Issue reference

No issue, but breaking docs PR: dapr/docs#3622

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
