### PR TITLE
Removes Python 3.7 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python_ver: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python_ver }}
@@ -50,10 +50,10 @@ jobs:
       TWINE_USERNAME: "__token__"
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_ver: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python_ver: [3.8, 3.9, "3.10", "3.11"]
     steps:
       - name: Parse repository_dispatch payload
         if: github.event_name == 'repository_dispatch'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This includes the following packages:
 ### Prerequisites
 
 * [Install Dapr standalone mode](https://github.com/dapr/cli#install-dapr-on-your-local-machine-standalone)
-* [Install Python 3.7+](https://www.python.org/downloads/)
+* [Install Python 3.8+](https://www.python.org/downloads/)
 
 ### Install Dapr python sdk
 

--- a/dapr/version/version.py
+++ b/dapr/version/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.9.0rc1.dev"
+__version__ = "1.11.0rc1.dev"

--- a/daprdocs/content/en/python-sdk-docs/_index.md
+++ b/daprdocs/content/en/python-sdk-docs/_index.md
@@ -18,7 +18,7 @@ Dapr offers a variety of subpackages to help with the development of Python appl
 
 - [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed
 - Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}})
-- [Python 3.7+](https://www.python.org/downloads/) installed
+- [Python 3.8+](https://www.python.org/downloads/) installed
 
 ## Installation
 

--- a/daprdocs/content/en/python-sdk-docs/python-actor.md
+++ b/daprdocs/content/en/python-sdk-docs/python-actor.md
@@ -12,7 +12,7 @@ The Dapr actor package allows you to interact with Dapr virtual actors from a Py
 
 - [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed
 - Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}})
-- [Python 3.7+](https://www.python.org/downloads/) installed
+- [Python 3.8+](https://www.python.org/downloads/) installed
 - [Dapr Python package]({{< ref "python#installation" >}}) installed
 
 ## Actor interface

--- a/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-workflow-ext/python-workflow.md
+++ b/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-workflow-ext/python-workflow.md
@@ -25,7 +25,7 @@ In the Python example project, the `app.py` file contains the setup of the app, 
 ## Prerequisites
 - [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed
 - Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}})
-- [Python 3.7+](https://www.python.org/downloads/) installed
+- [Python 3.8+](https://www.python.org/downloads/) installed
 - [Dapr Python package]({{< ref "python#installation" >}}) and the [workflow extension]({{< ref "python-workflow/_index.md" >}}) installed
 - Verify you're using the latest proto bindings
 

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -9,7 +9,7 @@ It demonstrates the following APIs:
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/demo_actor/README.md
+++ b/examples/demo_actor/README.md
@@ -10,7 +10,7 @@ This document describes how to create an Actor(DemoActor) and invoke its methods
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ### Install requirements
 

--- a/examples/demo_actor/demo_actor/Dockerfile
+++ b/examples/demo_actor/demo_actor/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7-slim-buster
+FROM python:3.9-slim-buster
 
 WORKDIR /app
 COPY . . 

--- a/examples/demo_actor/demo_actor/requirements.txt
+++ b/examples/demo_actor/demo_actor/requirements.txt
@@ -1,1 +1,1 @@
-dapr-ext-fastapi-dev>=1.9.0rc1.dev
+dapr-ext-fastapi-dev>=1.11.0rc1.dev

--- a/examples/demo_workflow/README.md
+++ b/examples/demo_workflow/README.md
@@ -12,7 +12,7 @@ It demonstrates the following APIs:
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ### Install requirements
 

--- a/examples/distributed_lock/README.md
+++ b/examples/distributed_lock/README.md
@@ -12,7 +12,7 @@ all the distributed lock API methods available as example.
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/grpc_proxying/README.md
+++ b/examples/grpc_proxying/README.md
@@ -7,7 +7,7 @@ This example creates a gRPC service using the protobuf file and adds it to the P
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/invoke-binding/README.md
+++ b/examples/invoke-binding/README.md
@@ -7,7 +7,7 @@ This example utilizes a publisher and a receiver for the InvokeBinding / OnBindi
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/invoke-custom-data/README.md
+++ b/examples/invoke-custom-data/README.md
@@ -7,7 +7,7 @@ This example utilizes a receiver and a caller for the OnInvoke / Invoke function
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/invoke-simple/Dockerfile
+++ b/examples/invoke-simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 WORKDIR /app
 

--- a/examples/invoke-simple/README.md
+++ b/examples/invoke-simple/README.md
@@ -7,7 +7,7 @@ This example utilizes a receiver and a caller for the OnInvoke / Invoke function
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/invoke-simple/requirements.txt
+++ b/examples/invoke-simple/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-grpc-dev >= 1.9.0rc1.dev
-dapr-dev >= 1.9.0rc1.dev
+dapr-ext-grpc-dev >= 1.11.0rc1.dev
+dapr-dev >= 1.11.0rc1.dev

--- a/examples/metadata/README.md
+++ b/examples/metadata/README.md
@@ -15,7 +15,7 @@ It creates a client using `DaprClient`, uses a set of components defined in the
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/pubsub-simple/README.md
+++ b/examples/pubsub-simple/README.md
@@ -10,7 +10,7 @@ The subscriber will tell dapr to retry delivery of the first message it receives
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/secret_store/README.md
+++ b/examples/secret_store/README.md
@@ -9,7 +9,7 @@ This example also illustrates the use of access control for secrets.
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/state_store/README.md
+++ b/examples/state_store/README.md
@@ -17,7 +17,7 @@ It uses the default configuration from Dapr init in [self-hosted mode](https://g
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/state_store_query/README.md
+++ b/examples/state_store_query/README.md
@@ -9,7 +9,7 @@ It demonstrates the following APIs:
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ## Install Dapr python-SDK
 

--- a/examples/w3c-tracing/Dockerfile
+++ b/examples/w3c-tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 WORKDIR /app
 

--- a/examples/w3c-tracing/README.md
+++ b/examples/w3c-tracing/README.md
@@ -15,7 +15,7 @@ This sample uses the Client provided in Dapr's Python SDK invoking a remote meth
 ## Pre-requisites
 
 - [Dapr CLI and initialized environment](https://docs.dapr.io/getting-started)
-- [Install Python 3.7+](https://www.python.org/downloads/)
+- [Install Python 3.8+](https://www.python.org/downloads/)
 
 ### Install dependencies
 

--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -1,5 +1,5 @@
-dapr-ext-grpc-dev >= 1.9.0rc1.dev
-dapr-dev >= 1.9.0rc1.dev
+dapr-ext-grpc-dev >= 1.11.0rc1.dev
+dapr-dev >= 1.11.0rc1.dev
 opencensus == 0.9.0
 opencensus-ext-grpc == 0.7.2
 opencensus-ext-zipkin == 0.2.2

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.9.0rc1.dev"
+__version__ = "1.11.0rc1.dev"

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -10,20 +10,20 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr-dev >= 1.9.0rc1.dev
+    dapr-dev >= 1.11.0rc1.dev
     uvicorn >= 0.11.6
     fastapi >= 0.60.1
 

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.9.0rc1.dev"
+__version__ = "1.11.0rc1.dev"

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -10,20 +10,20 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr-dev >= 1.9.0rc1.dev
+    dapr-dev >= 1.11.0rc1.dev
     cloudevents >= 1.0.0
 
 [options.packages.find]

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "0.0.1rc1.dev"
+__version__ = "0.2.0rc1.dev"

--- a/ext/dapr-ext-workflow/setup.cfg
+++ b/ext/dapr-ext-workflow/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -20,11 +19,11 @@ project_urls =
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr-dev >= 1.9.0rc1.dev
+    dapr-dev >= 1.11.0rc1.dev
     durabletask >= 0.1.0a2
 
 [options.packages.find]

--- a/ext/flask_dapr/flask_dapr/version.py
+++ b/ext/flask_dapr/flask_dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = "1.9.0rc1.dev"
+__version__ = "1.11.0rc1.dev"

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -10,19 +10,19 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
     Flask >= 1.1
-    dapr-dev >= 1.9.0rc1.dev
+    dapr-dev >= 1.11.0rc1.dev

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_unused_configs = True
 warn_redundant_casts = True
 show_error_codes = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,16 +10,16 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Documentation = https://github.com/dapr/docs
     Source = https://github.com/dapr/python-sdk
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 zip_safe = False

--- a/tests/clients/test_dapr_async_grpc_client.py
+++ b/tests/clients/test_dapr_async_grpc_client.py
@@ -17,7 +17,6 @@ import json
 import socket
 import unittest
 import uuid
-import sys
 
 from unittest.mock import patch
 
@@ -35,9 +34,6 @@ from dapr.clients.grpc._response import (
     ConfigurationResponse,
     UnlockResponseStatus,
 )
-
-if (sys.version_info.major, sys.version_info.minor) < (3, 8):
-    raise unittest.SkipTest()
 
 
 class DaprGrpcClientAsyncTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
# Description

Python 3.7 is no longer supported (end of life date has been exceeded). This PR removes Python 3.7 support. This also allows us to use Python 3.8 features in code and tests.