### PR TITLE
change call_child_workflow to pass correct wf name to durabletask worker

### DIFF
--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
@@ -62,7 +62,7 @@ class DaprWorkflowContext(WorkflowContext):
             daprWfContext = DaprWorkflowContext(ctx)
             return workflow(daprWfContext, inp)
         # copy workflow name so durabletask.worker can find the orchestrator in its registry
-        wf.__name__ = workflow.__name__ 
+        wf.__name__ = workflow.__name__
         return self.__obj.call_sub_orchestrator(wf, input=input, instance_id=instance_id)
 
     def wait_for_external_event(self, name: str) -> task.Task:

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
@@ -61,7 +61,8 @@ class DaprWorkflowContext(WorkflowContext):
         def wf(ctx: task.OrchestrationContext, inp: TInput):
             daprWfContext = DaprWorkflowContext(ctx)
             return workflow(daprWfContext, inp)
-        wf.__name__ = workflow.__name__ # copy workflow name so durabletask.worker can find the orchestrator in its registry
+        # copy workflow name so durabletask.worker can find the orchestrator in its registry
+        wf.__name__ = workflow.__name__ 
         return self.__obj.call_sub_orchestrator(wf, input=input, instance_id=instance_id)
 
     def wait_for_external_event(self, name: str) -> task.Task:

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_context.py
@@ -61,6 +61,7 @@ class DaprWorkflowContext(WorkflowContext):
         def wf(ctx: task.OrchestrationContext, inp: TInput):
             daprWfContext = DaprWorkflowContext(ctx)
             return workflow(daprWfContext, inp)
+        wf.__name__ = workflow.__name__ # copy workflow name so durabletask.worker can find the orchestrator in its registry
         return self.__obj.call_sub_orchestrator(wf, input=input, instance_id=instance_id)
 
     def wait_for_external_event(self, name: str) -> task.Task:


### PR DESCRIPTION
# Description

durabletask.worker uses `orchestrator.__name__` [here](https://github.com/microsoft/durabletask-python/blob/c9990973a7cc18b2db1219d129961cede9eb3948/durabletask/worker.py#L387)  

but when dapr_workflow_context wraps the real workflow function in `wf`, the correct orchestrator name is lost.

This bug results in the following exception:

```python
durabletask.task.TaskFailedError: Sub-orchestration task #1 failed: A 'wf' orchestrator was not registered.
```

when called as

```python
raw_download_result = yield ctx.call_child_workflow(
            workflow=files_com_wf.files_com_download_file_wf,
            input=path,
            instance_id=None,
        )
```

This proposed fix is not pretty, but it works.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #615

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation


There aren't any existing tests or even any examples that use call_child_workflow, I'm sorry I do not have time to write tests or documentation at this time.

