### PR TITLE
Updated endpoint parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# OSX specific files
+.DS_Store

--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -140,16 +140,16 @@ class DaprGrpcClientAsync:
                                                       f"{settings.DAPR_GRPC_PORT}")
 
         try:
-            self._endpoint = GrpcEndpoint(address)
+            self._uri = GrpcEndpoint(address)
         except ValueError as error:
             raise DaprInternalError(f'{error}') from error
 
-        if self._endpoint.is_secure():
-            self._channel = grpc.aio.secure_channel(self._endpoint.get_endpoint(),
+        if self._uri.tls:
+            self._channel = grpc.aio.secure_channel(self._uri.endpoint,
                                                     credentials=self.get_credentials(),
                                                     options=options)  # type: ignore
         else:
-            self._channel = grpc.aio.insecure_channel(self._endpoint.get_endpoint(),
+            self._channel = grpc.aio.insecure_channel(self._uri.endpoint,
                                                       options)  # type: ignore
 
         if settings.DAPR_API_TOKEN:
@@ -1446,7 +1446,7 @@ class DaprGrpcClientAsync:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(timeout_s)
                 try:
-                    s.connect((self._endpoint.get_hostname(), self._endpoint.get_port_as_int()))
+                    s.connect((self._uri.hostname, self._uri.port_as_int))
                     return
                 except Exception as e:
                     remaining = (start + timeout_s) - time.time()

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -139,16 +139,16 @@ class DaprGrpcClient:
                                                       f"{settings.DAPR_GRPC_PORT}")
 
         try:
-            self._endpoint = GrpcEndpoint(address)
+            self._uri = GrpcEndpoint(address)
         except ValueError as error:
             raise DaprInternalError(f'{error}') from error
 
-        if self._endpoint.is_secure():
-            self._channel = grpc.secure_channel(self._endpoint.get_endpoint(), # type: ignore
+        if self._uri.tls:
+            self._channel = grpc.secure_channel(self._uri.endpoint,  # type: ignore
                                                 self.get_credentials(),
                                                 options=options)
         else:
-            self._channel = grpc.insecure_channel(self._endpoint.get_endpoint(), # type: ignore
+            self._channel = grpc.insecure_channel(self._uri.endpoint,  # type: ignore
                                                   options=options)
 
         if settings.DAPR_API_TOKEN:
@@ -1434,7 +1434,7 @@ class DaprGrpcClient:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(timeout_s)
                 try:
-                    s.connect((self._endpoint.get_hostname(), self._endpoint.get_port_as_int()))
+                    s.connect((self._uri.hostname, self._uri.port_as_int))
                     return
                 except Exception as e:
                     remaining = (start + timeout_s) - time.time()

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -1,5 +1,4 @@
 from urllib.parse import urlparse, parse_qs
-from typing import Optional
 
 
 class URIParseConfig:
@@ -7,28 +6,45 @@ class URIParseConfig:
     DEFAULT_HOSTNAME = "localhost"
     DEFAULT_PORT = 443
     DEFAULT_TLS = False
+    DEFAULT_AUTHORITY = ""
     ACCEPTED_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "http", "https", "grpc", "grpcs"]
     VALID_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "grpc", "grpcs"]
 
 
-class Endpoint:
-    def __init__(self, scheme: str, hostname: str, port: Optional[int], tls: bool):
-        self.scheme = scheme or URIParseConfig.DEFAULT_SCHEME
-        self.hostname = hostname or URIParseConfig.DEFAULT_HOSTNAME
-        self.port = port or URIParseConfig.DEFAULT_PORT
+class GrpcEndpoint:
+    def __init__(self, url: str):
+        self.authority = URIParseConfig.DEFAULT_AUTHORITY
+        self.url = url
+
+        url = self.preprocess_url(url)
+        parsed_url = urlparse(url)
+        validate_path_and_query(parsed_url.path, parsed_url.query, parsed_url.scheme)
+        tls = extract_tls_from_query(parsed_url.query, parsed_url.scheme)
+
+        self.scheme = parsed_url.scheme or URIParseConfig.DEFAULT_SCHEME
+        self.hostname = parsed_url.hostname or URIParseConfig.DEFAULT_HOSTNAME
+        self.port = parsed_url.port or URIParseConfig.DEFAULT_PORT
         self.tls = tls or URIParseConfig.DEFAULT_TLS
 
     def is_secure(self) -> bool:
         return self.tls
 
     def get_scheme(self) -> str:
-        return self.scheme if self.scheme in URIParseConfig.VALID_SCHEMES else URIParseConfig.DEFAULT_SCHEME
+        return self.scheme if self.scheme in URIParseConfig.VALID_SCHEMES \
+            else URIParseConfig.DEFAULT_SCHEME
 
     def get_port(self) -> str:
-        if self.scheme in ["unix", "unix-abstract", "vsock"]:
+        port = self.get_port_as_int()
+        if port == 0:
             return ""
 
-        return str(self.port)
+        return str(port)
+
+    def get_port_as_int(self) -> int:
+        if self.scheme in ["unix", "unix-abstract"]:
+            return 0
+
+        return self.port
 
     def get_hostname(self) -> str:
         hostname = self.hostname
@@ -39,37 +55,58 @@ class Endpoint:
 
     def get_endpoint(self) -> str:
         scheme = self.get_scheme()
-        if scheme in ["unix", "unix-abstract", "vsock"]:
-            return f"{scheme}://{self.hostname}"
+        port = "" if len(self.get_port()) == 0 else f":{self.port}"
 
-        return f"{scheme}:{self.get_hostname()}:{self.get_port()}"
+        if scheme == "unix":
+            separator = "://" if self.url.startswith("unix://") else ":"
+            return f"{scheme}{separator}{self.hostname}"
 
+        if scheme == "vsock":
+            port = "" if self.port == 0 else f":{self.port}"
+            return f"{scheme}:{self.get_hostname()}{port}"
 
-def parse_grpc_endpoint(url: str) -> Endpoint:
-    url = preprocess_url(url)
-    parsed_url = urlparse(url)
-    validate_path_and_query(parsed_url.path, parsed_url.query, parsed_url.scheme)
-    tls = extract_tls_from_query(parsed_url.query, parsed_url.scheme)
+        if scheme == "unix-abstract":
+            return f"{scheme}:{self.get_hostname()}{port}"
 
-    return Endpoint(parsed_url.scheme, parsed_url.hostname, parsed_url.port, tls)
+        if scheme == "dns":
+            authority = f"//{self.authority}/" if self.authority else ""
+            return f"{scheme}:{authority}{self.get_hostname()}{port}"
 
+        return f"{scheme}:{self.get_hostname()}{port}"
 
-def preprocess_url(url: str) -> str:
-    url_list = url.split(":")
-    if len(url_list) == 3 and "://" not in url:
-        # A URI like dns:mydomain:5000 was used
-        url = url.replace(":", "://", 1)
-    elif len(url_list) == 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
-        # A URI like dns:mydomain was used
-        url = url.replace(":", "://", 1)
-    else:
-        url_list = url.split("://")
-        if len(url_list) == 1:
-            # If a scheme was not explicitly specified in the URL
-            # we need to add a default scheme,
-            # because of how urlparse works
-            url = f'{URIParseConfig.DEFAULT_SCHEME}://{url}'
-    return url
+    def preprocess_url(self, url: str) -> str:
+        url_list = url.split(":")
+        if len(url_list) == 3 and "://" not in url:
+            # A URI like dns:mydomain:5000 or vsock:mycid:5000 was used
+            url = url.replace(":", "://", 1)
+        elif len(url_list) == 2 and "://" not in url and url_list[
+                0] in URIParseConfig.ACCEPTED_SCHEMES:
+            # A URI like dns:mydomain was used
+            url = url.replace(":", "://", 1)
+        else:
+            url_list = url.split("://")
+            if len(url_list) == 1:
+                # If a scheme was not explicitly specified in the URL
+                # we need to add a default scheme,
+                # because of how urlparse works
+                url = f'{URIParseConfig.DEFAULT_SCHEME}://{url}'
+            else:
+                # If a scheme was explicitly specified in the URL
+                # we need to make sure it is a valid scheme
+                scheme = url_list[0]
+                if scheme not in URIParseConfig.ACCEPTED_SCHEMES:
+                    raise ValueError(f"Invalid scheme '{scheme}' in URL '{url}'")
+
+                # We should do a special check if the scheme is dns, and it uses
+                # an authority in the format of dns:[//authority/]host[:port]
+                if scheme.lower() == "dns":
+                    # A URI like dns://authority/mydomain was used
+                    url_list = url.split("/")
+                    if len(url_list) < 4:
+                        raise ValueError(f"Invalid dns authority '{url_list[2]}' in URL '{url}'")
+                    self.authority = url_list[2]
+                    url = f'dns://{url_list[3]}'
+        return url
 
 
 def validate_path_and_query(path: str, query: str, scheme: str) -> None:
@@ -87,8 +124,8 @@ def validate_path_and_query(path: str, query: str, scheme: str) -> None:
 
 def extract_tls_from_query(query: str, scheme: str) -> bool:
     query_dict = parse_qs(query)
-    tls = query_dict.get('tls', [None])[0]
-    tls = tls and tls.lower() == 'true'
+    tls_str = query_dict.get('tls', [""])[0]
+    tls = tls_str.lower() == 'true'
     if scheme == "https":
         tls = True
     return tls

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -129,6 +129,9 @@ class GrpcEndpoint:
                 0] in URIParseConfig.ACCEPTED_SCHEMES:
             # A URI like dns:mydomain was used
             url = url.replace(":", "://", 1)
+        elif len(url_list) > 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
+            # Possibly a URI like dns:[2001:db8:1f70::999:de8:7648:6e8]:mydomain was used
+            url = url.replace(":", "://", 1)
         else:
             url_list = url.split("://")
             if len(url_list) == 1:

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -6,10 +6,8 @@ class URIParseConfig:
     DEFAULT_SCHEME = "dns"
     DEFAULT_HOSTNAME = "localhost"
     DEFAULT_PORT = 443
-    DEFAULT_TLS = False
     DEFAULT_AUTHORITY = ""
     ACCEPTED_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "http", "https", "grpc", "grpcs"]
-    VALID_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "grpc", "grpcs"]
 
 
 class GrpcEndpoint:
@@ -125,11 +123,8 @@ class GrpcEndpoint:
         if len(url_list) == 3 and "://" not in url:
             # A URI like dns:mydomain:5000 or vsock:mycid:5000 was used
             url = url.replace(":", "://", 1)
-        elif len(url_list) == 2 and "://" not in url and url_list[
-                0] in URIParseConfig.ACCEPTED_SCHEMES:
-            # A URI like dns:mydomain was used
-            url = url.replace(":", "://", 1)
-        elif len(url_list) > 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
+        elif len(url_list) >= 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
+            # A URI like dns:mydomain or dns:[2001:db8:1f70::999:de8:7648:6e8]:mydomain was used
             # Possibly a URI like dns:[2001:db8:1f70::999:de8:7648:6e8]:mydomain was used
             url = url.replace(":", "://", 1)
         else:

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -1,59 +1,65 @@
 from urllib.parse import urlparse, parse_qs
+from typing import Optional
 
-DEFAULT_SCHEME = "dns"
-DEFAULT_HOSTNAME = "localhost"
-DEFAULT_PORT = 443
-DEFAULT_PATH = ""
-DEFAULT_QUERY = ""
-DEFAULT_TLS_PORT = 443
-DEFAULT_TLS = False
-ACCEPTED_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "http", "https", "grpc", "grpcs"]
-VALID_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "grpc", "grpcs"]
+
+class URIParseConfig:
+    DEFAULT_SCHEME = "dns"
+    DEFAULT_HOSTNAME = "localhost"
+    DEFAULT_PORT = 443
+    DEFAULT_TLS = False
+    ACCEPTED_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "http", "https", "grpc", "grpcs"]
+    VALID_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "grpc", "grpcs"]
 
 
 class Endpoint:
-    scheme: str
-    hostname: str
-    port: int
-    path: str
-    query: str
-    tls: bool
-
-    def __init__(self, scheme: str, hostname: str, port: int, path: str, query: str, tls: bool):
-        self.scheme = scheme or DEFAULT_SCHEME
-        self.hostname = hostname or DEFAULT_HOSTNAME
-        self.port = port or DEFAULT_PORT
-        self.path = path or DEFAULT_PATH
-        self.query = query or DEFAULT_QUERY
-        self.tls = tls or DEFAULT_TLS
+    def __init__(self, scheme: str, hostname: str, port: Optional[int], tls: bool):
+        self.scheme = scheme or URIParseConfig.DEFAULT_SCHEME
+        self.hostname = hostname or URIParseConfig.DEFAULT_HOSTNAME
+        self.port = port or URIParseConfig.DEFAULT_PORT
+        self.tls = tls or URIParseConfig.DEFAULT_TLS
 
     def is_secure(self) -> bool:
         return self.tls
 
     def get_scheme(self) -> str:
-        return self.scheme if self.scheme in VALID_SCHEMES else DEFAULT_SCHEME
+        return self.scheme if self.scheme in URIParseConfig.VALID_SCHEMES else URIParseConfig.DEFAULT_SCHEME
 
     def get_port(self) -> str:
+        if self.scheme in ["unix", "unix-abstract", "vsock"]:
+            return ""
+
         return str(self.port)
 
     def get_hostname(self) -> str:
         hostname = self.hostname
-        hostname_list = hostname.split(":")
-        if len(hostname_list) == 8:
+        if self.hostname.count(":") == 7:
             # IPv6 address
             hostname = f"[{hostname}]"
         return hostname
 
     def get_endpoint(self) -> str:
-        return f"{self.get_scheme()}:{self.get_hostname()}:{self.get_port()}"
+        scheme = self.get_scheme()
+        if scheme in ["unix", "unix-abstract", "vsock"]:
+            return f"{scheme}://{self.hostname}"
+
+        return f"{scheme}:{self.get_hostname()}:{self.get_port()}"
 
 
 def parse_grpc_endpoint(url: str) -> Endpoint:
+    url = preprocess_url(url)
+    parsed_url = urlparse(url)
+    validate_path_and_query(parsed_url.path, parsed_url.query, parsed_url.scheme)
+    tls = extract_tls_from_query(parsed_url.query, parsed_url.scheme)
+
+    return Endpoint(parsed_url.scheme, parsed_url.hostname, parsed_url.port, tls)
+
+
+def preprocess_url(url: str) -> str:
     url_list = url.split(":")
     if len(url_list) == 3 and "://" not in url:
         # A URI like dns:mydomain:5000 was used
         url = url.replace(":", "://", 1)
-    elif len(url_list) == 2 and "://" not in url and url_list[0] in ACCEPTED_SCHEMES:
+    elif len(url_list) == 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
         # A URI like dns:mydomain was used
         url = url.replace(":", "://", 1)
     else:
@@ -62,37 +68,27 @@ def parse_grpc_endpoint(url: str) -> Endpoint:
             # If a scheme was not explicitly specified in the URL
             # we need to add a default scheme,
             # because of how urlparse works
-            url = f'{DEFAULT_SCHEME}://{url}'
+            url = f'{URIParseConfig.DEFAULT_SCHEME}://{url}'
+    return url
 
-    parsed_url = urlparse(url)
-    scheme = parsed_url.scheme
-    hostname = parsed_url.hostname or DEFAULT_HOSTNAME
-    port = parsed_url.port
-    path = parsed_url.path
-    query = parsed_url.query
 
-    if len(path) > 0:
-        raise ValueError(f"paths are not supported for gRPC endpoints: '{path}' in '{url}'")
+def validate_path_and_query(path: str, query: str, scheme: str) -> None:
+    if path:
+        raise ValueError(f"Paths are not supported for gRPC endpoints: '{path}'")
+    if query:
+        query_dict = parse_qs(query)
+        if 'tls' in query_dict and scheme in ["http", "https"]:
+            raise ValueError(
+                f"The tls query parameter is not supported for http(s) endpoints: '{query}'")
+        query_dict.pop('tls', None)
+        if query_dict:
+            raise ValueError(f"Query parameters are not supported for gRPC endpoints: '{query}'")
 
+
+def extract_tls_from_query(query: str, scheme: str) -> bool:
     query_dict = parse_qs(query)
-
-    # Check if the query string contains a tls parameter
-    tls = False
-    if 'tls' in query_dict and scheme in ["http", "https"]:
-        raise ValueError(
-            f"the tls query parameter is not supported for http(s) endpoints: '{query}' in '{url}'")
-    if 'tls' in query_dict:
-        tls = query_dict.get('tls')[0].lower() == "true"
-
-    # Special case for backwards compatibility
+    tls = query_dict.get('tls', [None])[0]
+    tls = tls and tls.lower() == 'true'
     if scheme == "https":
         tls = True
-        scheme = DEFAULT_SCHEME
-        port = port or DEFAULT_TLS_PORT
-
-    query_dict.pop('tls', None)
-    if len(query_dict) > 0:
-        raise ValueError(
-            f"query parameters are not supported for gRPC endpoints: '{query}' in '{url}'")
-
-    return Endpoint(scheme, hostname, port, path, query, tls)
+    return tls

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -1,13 +1,14 @@
-from typing import Tuple
 from urllib.parse import urlparse, parse_qs
 
-DEFAULT_SCHEME = "grpc"
+DEFAULT_SCHEME = "dns"
 DEFAULT_HOSTNAME = "localhost"
-DEFAULT_PORT = 50001
+DEFAULT_PORT = 443
 DEFAULT_PATH = ""
 DEFAULT_QUERY = ""
 DEFAULT_TLS_PORT = 443
 DEFAULT_TLS = False
+ACCEPTED_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "http", "https", "grpc", "grpcs"]
+VALID_SCHEMES = ["dns", "unix", "unix-abstract", "vsock", "grpc", "grpcs"]
 
 
 class Endpoint:
@@ -29,17 +30,39 @@ class Endpoint:
     def is_secure(self) -> bool:
         return self.tls
 
-    def to_string(self) -> str:
-        return f"{self.scheme}://{self.hostname}:{self.port}"
+    def get_scheme(self) -> str:
+        return self.scheme if self.scheme in VALID_SCHEMES else DEFAULT_SCHEME
+
+    def get_port(self) -> str:
+        return str(self.port)
+
+    def get_hostname(self) -> str:
+        hostname = self.hostname
+        hostname_list = hostname.split(":")
+        if len(hostname_list) == 8:
+            # IPv6 address
+            hostname = f"[{hostname}]"
+        return hostname
+
+    def get_endpoint(self) -> str:
+        return f"{self.get_scheme()}:{self.get_hostname()}:{self.get_port()}"
 
 
 def parse_grpc_endpoint(url: str) -> Endpoint:
-    # If a scheme was not explicitly specified in the URL
-    # we need to add a default scheme,
-    # because of how urlparse works
-    url_list = url.split("://")
-    if len(url_list) == 1:
-        url = f'{DEFAULT_SCHEME}://{url}'
+    url_list = url.split(":")
+    if len(url_list) == 3 and "://" not in url:
+        # A URI like dns:mydomain:5000 was used
+        url = url.replace(":", "://", 1)
+    elif len(url_list) == 2 and "://" not in url and url_list[0] in ACCEPTED_SCHEMES:
+        # A URI like dns:mydomain was used
+        url = url.replace(":", "://", 1)
+    else:
+        url_list = url.split("://")
+        if len(url_list) == 1:
+            # If a scheme was not explicitly specified in the URL
+            # we need to add a default scheme,
+            # because of how urlparse works
+            url = f'{DEFAULT_SCHEME}://{url}'
 
     parsed_url = urlparse(url)
     scheme = parsed_url.scheme
@@ -51,10 +74,15 @@ def parse_grpc_endpoint(url: str) -> Endpoint:
     if len(path) > 0:
         raise ValueError(f"paths are not supported for gRPC endpoints: '{path}' in '{url}'")
 
-    # Check if the query string contains a tls parameter
     query_dict = parse_qs(query)
-    tls = query_dict.get('tls', ["False"])
-    tls = True if tls and tls[0].lower() == 'true' else False
+
+    # Check if the query string contains a tls parameter
+    tls = False
+    if 'tls' in query_dict and scheme in ["http", "https"]:
+        raise ValueError(
+            f"the tls query parameter is not supported for http(s) endpoints: '{query}' in '{url}'")
+    if 'tls' in query_dict:
+        tls = query_dict.get('tls')[0].lower() == "true"
 
     # Special case for backwards compatibility
     if scheme == "https":

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -123,7 +123,9 @@ class GrpcEndpoint:
         if len(url_list) == 3 and "://" not in url:
             # A URI like dns:mydomain:5000 or vsock:mycid:5000 was used
             url = url.replace(":", "://", 1)
-        elif len(url_list) >= 2 and "://" not in url and url_list[0] in URIParseConfig.ACCEPTED_SCHEMES:
+        elif len(url_list) >= 2 and "://" not in url and url_list[
+                0] in URIParseConfig.ACCEPTED_SCHEMES:
+
             # A URI like dns:mydomain or dns:[2001:db8:1f70::999:de8:7648:6e8]:mydomain was used
             # Possibly a URI like dns:[2001:db8:1f70::999:de8:7648:6e8]:mydomain was used
             url = url.replace(":", "://", 1)

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -1,3 +1,4 @@
+from warnings import warn
 from urllib.parse import urlparse, parse_qs, ParseResult
 
 
@@ -35,8 +36,13 @@ class GrpcEndpoint:
         self._set_endpoint()
 
     def _set_scheme(self):
-        if len(self._parsed_url.scheme) == 0 or self._parsed_url.scheme in ["http", "https"]:
+        if len(self._parsed_url.scheme) == 0:
             self._scheme = URIParseConfig.DEFAULT_SCHEME
+            return
+
+        if self._parsed_url.scheme in ["http", "https"]:
+            self._scheme = URIParseConfig.DEFAULT_SCHEME
+            warn("http and https schemes are deprecated, use grpc or grpcs instead")
             return
 
         if self._parsed_url.scheme not in URIParseConfig.ACCEPTED_SCHEMES:

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -101,8 +101,7 @@ class GrpcEndpoint:
             return
 
         if self._scheme == "vsock":
-            port = "" if self.port == 0 else f":{self.port}"
-            self._endpoint = f"{self._scheme}:{self._hostname}{port}"
+            self._endpoint = f"{self._scheme}:{self._hostname}:{self.port}"
             return
 
         if self._scheme == "unix-abstract":

--- a/daprdocs/content/en/python-sdk-docs/python-client.md
+++ b/daprdocs/content/en/python-sdk-docs/python-client.md
@@ -39,7 +39,7 @@ with DaprClient() as d:
 ```
 
 #### Specifying an endpoint on initialisation:  
-When passed as an argument in the constructor, the endpoint takes precedence over any configuration or environment variable.
+When passed as an argument in the constructor, the gRPC endpoint takes precedence over any configuration or environment variable.
 
 ```python
 from dapr.clients import DaprClient
@@ -48,14 +48,13 @@ with DaprClient("mydomain:50051?tls=true") as d:
     # use the client
 ```  
 
-#### Specifying an endpoint in an environment variable:  
-You can use the standardised `DAPR_GRPC_ENDPOINT` and/or `DAPR_HTTP_ENDPOINT` environment variables to
-specify the endpoint. When these environment variables are set, the client can be initialised 
+#### Specifying the endpoint in an environment variable:  
+You can use the standardised `DAPR_GRPC_ENDPOINT` environment variable to
+specify the gRPC endpoint. When this variable is set, the client can be initialised 
 without any arguments:
 
 ```bash
 export DAPR_GRPC_ENDPOINT="mydomain:50051?tls=true"
-export DAPR_HTTP_ENDPOINT="https://mydomain:443"
 ```
 ```python
 from dapr.clients import DaprClient
@@ -65,7 +64,7 @@ with DaprClient() as d:
 ```  
 
 The legacy environment variables `DAPR_RUNTIME_HOST`, `DAPR_HTTP_PORT` and `DAPR_GRPC_PORT` are 
-also supported, but `DAPR_GRPC_ENDPOINT` and `DAPR_HTTP_ENDPOINT` take precedence.
+also supported, but `DAPR_GRPC_ENDPOINT` takes precedence.
 
 
 ## Building blocks

--- a/daprdocs/content/en/python-sdk-docs/python-client.md
+++ b/daprdocs/content/en/python-sdk-docs/python-client.md
@@ -44,19 +44,25 @@ When passed as an argument in the constructor, the endpoint takes precedence ove
 ```python
 from dapr.clients import DaprClient
 
-with DaprClient("https://mydomain:4443") as d:
+with DaprClient("mydomain:50051?tls=true") as d:
     # use the client
 ```  
 
 #### Specifying an endpoint in an environment variable:  
 You can use the standardised `DAPR_GRPC_ENDPOINT` and/or `DAPR_HTTP_ENDPOINT` environment variables to
 specify the endpoint. When these environment variables are set, the client can be initialised 
-without any arguments.
+without any arguments:
 
 ```bash
-export DAPR_GRPC_ENDPOINT="https://mydomain:50051"
+export DAPR_GRPC_ENDPOINT="mydomain:50051?tls=true"
 export DAPR_HTTP_ENDPOINT="https://mydomain:443"
 ```
+```python
+from dapr.clients import DaprClient
+
+with DaprClient() as d:
+    # the client will use the endpoint specified in the environment variables
+```  
 
 The legacy environment variables `DAPR_RUNTIME_HOST`, `DAPR_HTTP_PORT` and `DAPR_GRPC_PORT` are 
 also supported, but `DAPR_GRPC_ENDPOINT` and `DAPR_HTTP_ENDPOINT` take precedence.

--- a/tests/clients/test_secure_dapr_async_grpc_client.py
+++ b/tests/clients/test_secure_dapr_async_grpc_client.py
@@ -53,25 +53,25 @@ class DaprSecureGrpcClientAsyncTests(DaprGrpcClientAsyncTests):
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT(self):
         dapr = DaprGrpcClientAsync()
-        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain1.com:5000", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_argument(self):
         dapr = DaprGrpcClientAsync("https://domain2.com:5002")
-        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain2.com:5002", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain2.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5002")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClientAsync()
-        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain1.com:5000", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain1.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5000")
     def test_init_with_argument_and_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClientAsync("https://domain2.com:5002")
-        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain2.com:5002", dapr._uri.endpoint)
 
     async def test_dapr_api_token_insertion(self):
         pass

--- a/tests/clients/test_secure_dapr_async_grpc_client.py
+++ b/tests/clients/test_secure_dapr_async_grpc_client.py
@@ -53,33 +53,25 @@ class DaprSecureGrpcClientAsyncTests(DaprGrpcClientAsyncTests):
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT(self):
         dapr = DaprGrpcClientAsync()
-        self.assertEqual("domain1.com", dapr._hostname)
-        self.assertEqual(5000, dapr._port)
-        self.assertEqual("https", dapr._scheme)
+        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_argument(self):
         dapr = DaprGrpcClientAsync("https://domain2.com:5002")
-        self.assertEqual("domain2.com", dapr._hostname)
-        self.assertEqual(5002, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain2.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5002")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClientAsync()
-        self.assertEqual("domain1.com", dapr._hostname)
-        self.assertEqual(5000, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain1.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5000")
     def test_init_with_argument_and_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClientAsync("https://domain2.com:5002")
-        self.assertEqual("domain2.com", dapr._hostname)
-        self.assertEqual(5002, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
 
     async def test_dapr_api_token_insertion(self):
         pass

--- a/tests/clients/test_secure_dapr_grpc_client.py
+++ b/tests/clients/test_secure_dapr_grpc_client.py
@@ -51,25 +51,25 @@ class DaprSecureGrpcClientTests(DaprGrpcClientTests):
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT(self):
         dapr = DaprGrpcClient()
-        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain1.com:5000", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_argument(self):
         dapr = DaprGrpcClient("https://domain2.com:5002")
-        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain2.com:5002", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain2.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5002")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClient()
-        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain1.com:5000", dapr._uri.endpoint)
 
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain1.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5000")
     def test_init_with_argument_and_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClient("https://domain2.com:5002")
-        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
+        self.assertEqual("dns:domain2.com:5002", dapr._uri.endpoint)
 
 
 if __name__ == '__main__':

--- a/tests/clients/test_secure_dapr_grpc_client.py
+++ b/tests/clients/test_secure_dapr_grpc_client.py
@@ -51,33 +51,25 @@ class DaprSecureGrpcClientTests(DaprGrpcClientTests):
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT(self):
         dapr = DaprGrpcClient()
-        self.assertEqual("domain1.com", dapr._hostname)
-        self.assertEqual(5000, dapr._port)
-        self.assertEqual("https", dapr._scheme)
+        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_argument(self):
         dapr = DaprGrpcClient("https://domain2.com:5002")
-        self.assertEqual("domain2.com", dapr._hostname)
-        self.assertEqual(5002, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_GRPC_ENDPOINT", "https://domain1.com:5000")
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain2.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5002")
     def test_init_with_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClient()
-        self.assertEqual("domain1.com", dapr._hostname)
-        self.assertEqual(5000, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain1.com:5000", dapr._endpoint.get_endpoint())
 
     @patch.object(settings, "DAPR_RUNTIME_HOST", "domain1.com")
     @patch.object(settings, "DAPR_GRPC_PORT", "5000")
     def test_init_with_argument_and_DAPR_GRPC_ENDPOINT_and_DAPR_RUNTIME_HOST(self):
         dapr = DaprGrpcClient("https://domain2.com:5002")
-        self.assertEqual("domain2.com", dapr._hostname)
-        self.assertEqual(5002, dapr._port)
-        self.assertEqual('https', dapr._scheme)
+        self.assertEqual("dns:domain2.com:5002", dapr._endpoint.get_endpoint())
 
 
 if __name__ == '__main__':

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -1,144 +1,161 @@
 import unittest
 
-from dapr.conf.helpers import parse_endpoint
+from dapr.conf.helpers import parse_endpoint, parse_http_endpoint
 
 
 class DaprClientHelpersTests(unittest.TestCase):
 
-    def test_parse_endpoint(self):
+    def test_parse_http_endpoint(self):
+        # testcases = [
+        #     {
+        #         "endpoint": "localhost",
+        #         "scheme": "dns",
+        #
+        #     }
+        # ]
+
         testcases = [{"endpoint": ":5000", "scheme": "http", "host": "localhost", "port": 5000},
                      {"endpoint": ":5000/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
 
-                     {"endpoint": "localhost", "scheme": "http", "host": "localhost", "port": 80},
+                     {"endpoint": "localhost", "scheme": "http", "host": "localhost", "port": 80,
+                      "tls": False},
                      {"endpoint": "localhost/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "localhost:5000", "scheme": "http", "host": "localhost",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
                      {"endpoint": "localhost:5000/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
 
                      {"endpoint": "http://localhost", "scheme": "http", "host": "localhost",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "http://localhost/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "http://localhost:5000", "scheme": "http", "host": "localhost",
-                      "port": 5000}, {"endpoint": "http://localhost:5000/v1/dapr", "scheme": "http",
-                                      "host": "localhost", "port": 5000},
+                      "port": 5000, "tls": False},
+                     {"endpoint": "http://localhost:5000/v1/dapr", "scheme": "http",
+                      "host": "localhost", "port": 5000, "tls": False},
 
                      {"endpoint": "https://localhost", "scheme": "https", "host": "localhost",
-                      "port": 443}, {"endpoint": "https://localhost/v1/dapr", "scheme": "https",
-                                     "host": "localhost", "port": 443},
+                      "port": 443, "tls": True},
+                     {"endpoint": "https://localhost/v1/dapr", "scheme": "https",
+                                     "host": "localhost", "port": 443, "tls": True},
                      {"endpoint": "https://localhost:5000", "scheme": "https", "host": "localhost",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
                      {"endpoint": "https://localhost:5000/v1/dapr", "scheme": "https",
-                      "host": "localhost", "port": 5000},
+                      "host": "localhost", "port": 5000, "tls": True},
 
-                     {"endpoint": "127.0.0.1", "scheme": "http", "host": "127.0.0.1", "port": 80},
+                     {"endpoint": "127.0.0.1", "scheme": "http", "host": "127.0.0.1", "port": 80, "tls": False},
                      {"endpoint": "127.0.0.1/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "127.0.0.1:5000", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
                      {"endpoint": "127.0.0.1:5000/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
 
                      {"endpoint": "http://127.0.0.1", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "http://127.0.0.1/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "http://127.0.0.1:5000", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000}, {"endpoint": "http://127.0.0.1:5000/v1/dapr", "scheme": "http",
-                                      "host": "127.0.0.1", "port": 5000},
+                      "port": 5000, "tls": False}, {"endpoint": "http://127.0.0.1:5000/v1/dapr", "scheme": "http",
+                                      "host": "127.0.0.1", "port": 5000, "tls": False},
 
                      {"endpoint": "https://127.0.0.1", "scheme": "https", "host": "127.0.0.1",
-                      "port": 443}, {"endpoint": "https://127.0.0.1/v1/dapr", "scheme": "https",
-                                     "host": "127.0.0.1", "port": 443},
+                      "port": 443, "tls": True},
+                     {"endpoint": "https://127.0.0.1/v1/dapr", "scheme": "https",
+                                     "host": "127.0.0.1", "port": 443, "tls": True},
                      {"endpoint": "https://127.0.0.1:5000", "scheme": "https", "host": "127.0.0.1",
-                      "port": 5000},
+                      "port": 5000, "tls": True},
                      {"endpoint": "https://127.0.0.1:5000/v1/dapr", "scheme": "https",
-                      "host": "127.0.0.1", "port": 5000},
+                      "host": "127.0.0.1", "port": 5000, "tls": True},
 
                      {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
                      {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
                      {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]:5000", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
                      {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
 
                      {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
                      {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80},
+                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
                      {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]:5000", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
                      {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
 
                      {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "https",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443},
+                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443, "tls": True},
                      {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443},
+                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443, "tls": True},
                      {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": True},
                      {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000},
+                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": True},
 
-                     {"endpoint": "domain.com", "scheme": "http", "host": "domain.com", "port": 80},
+                     {"endpoint": "domain.com", "scheme": "http", "host": "domain.com", "port": 80, "tls": False},
                      {"endpoint": "domain.com/v1/grpc", "scheme": "http", "host": "domain.com",
-                      "port": 80},
+                      "port": 80, "tls": False},
                      {"endpoint": "domain.com:5000", "scheme": "http", "host": "domain.com",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
                      {"endpoint": "domain.com:5000/v1/dapr", "scheme": "http", "host": "domain.com",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
 
                      {"endpoint": "http://domain.com", "scheme": "http", "host": "domain.com",
-                      "port": 80}, {"endpoint": "http://domain.com/v1/dapr", "scheme": "http",
-                                    "host": "domain.com", "port": 80},
+                      "port": 80, "tls": False},
+                     {"endpoint": "http://domain.com/v1/dapr", "scheme": "http",
+                                    "host": "domain.com", "port": 80, "tls": False},
                      {"endpoint": "http://domain.com:5000", "scheme": "http", "host": "domain.com",
-                      "port": 5000},
+                      "port": 5000, "tls": False},
                      {"endpoint": "http://domain.com:5000/v1/dapr", "scheme": "http",
-                      "host": "domain.com", "port": 5000},
+                      "host": "domain.com", "port": 5000, "tls": False},
 
                      {"endpoint": "https://domain.com", "scheme": "https", "host": "domain.com",
-                      "port": 443}, {"endpoint": "https://domain.com/v1/dapr", "scheme": "https",
-                                     "host": "domain.com", "port": 443},
+                      "port": 443, "tls": True},
+                     {"endpoint": "https://domain.com/v1/dapr", "scheme": "https",
+                                     "host": "domain.com", "port": 443, "tls": True},
                      {"endpoint": "https://domain.com:5000", "scheme": "https",
-                      "host": "domain.com", "port": 5000},
+                      "host": "domain.com", "port": 5000, "tls": True},
                      {"endpoint": "https://domain.com:5000/v1/dapr", "scheme": "https",
-                      "host": "domain.com", "port": 5000},
+                      "host": "domain.com", "port": 5000, "tls": True},
 
                      {"endpoint": "abc.domain.com", "scheme": "http", "host": "abc.domain.com",
-                      "port": 80}, {"endpoint": "abc.domain.com/v1/grpc", "scheme": "http",
-                                    "host": "abc.domain.com", "port": 80},
+                      "port": 80, "tls": False},
+                     {"endpoint": "abc.domain.com/v1/grpc", "scheme": "http",
+                                    "host": "abc.domain.com", "port": 80, "tls": False},
                      {"endpoint": "abc.domain.com:5000", "scheme": "http", "host": "abc.domain.com",
-                      "port": 5000}, {"endpoint": "abc.domain.com:5000/v1/dapr", "scheme": "http",
-                                      "host": "abc.domain.com", "port": 5000},
+                      "port": 5000, "tls": False},
+                     {"endpoint": "abc.domain.com:5000/v1/dapr", "scheme": "http",
+                                      "host": "abc.domain.com", "port": 5000, "tls": False},
 
                      {"endpoint": "http://abc.domain.com/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 80},
+                      "host": "abc.domain.com", "port": 80, "tls": False},
                      {"endpoint": "http://abc.domain.com/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 80},
+                      "host": "abc.domain.com", "port": 80, "tls": False},
                      {"endpoint": "http://abc.domain.com:5000/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 5000},
+                      "host": "abc.domain.com", "port": 5000, "tls": False},
                      {"endpoint": "http://abc.domain.com:5000/v1/dapr/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 5000},
+                      "host": "abc.domain.com", "port": 5000, "tls": False},
 
                      {"endpoint": "https://abc.domain.com/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 443},
+                      "host": "abc.domain.com", "port": 443, "tls": True},
                      {"endpoint": "https://abc.domain.com/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 443},
+                      "host": "abc.domain.com", "port": 443, "tls": True},
                      {"endpoint": "https://abc.domain.com:5000/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 5000},
+                      "host": "abc.domain.com", "port": 5000, "tls": True},
                      {"endpoint": "https://abc.domain.com:5000/v1/dapr/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 5000},
+                      "host": "abc.domain.com", "port": 5000, "tls": True},
 
                      ]
 
         for testcase in testcases:
-            o = parse_endpoint(testcase["endpoint"])
+            print(testcase["endpoint"])
+            o = parse_http_endpoint(testcase["endpoint"])
 
-            self.assertEqual(testcase["scheme"], o[0])
-            self.assertEqual(testcase["host"], o[1])
-            self.assertEqual(testcase["port"], o[2])
+            self.assertEqual(testcase["scheme"], o["scheme"])
+            self.assertEqual(testcase["host"], o["hostname"])
+            self.assertEqual(testcase["port"], o["port"])

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -1,161 +1,99 @@
 import unittest
 
-from dapr.conf.helpers import parse_endpoint, parse_http_endpoint
+from dapr.conf.helpers import parse_endpoint, parse_grpc_endpoint
 
 
 class DaprClientHelpersTests(unittest.TestCase):
 
-    def test_parse_http_endpoint(self):
-        # testcases = [
-        #     {
-        #         "endpoint": "localhost",
-        #         "scheme": "dns",
-        #
-        #     }
-        # ]
+    def test_parse_grpc_endpoint(self):
+        testcases = [
+            # Port only
+            # {"url": ":5000", "error": False, "secure": False, "scheme": "", "host": "localhost",
+            #  "port": 5000, "endpoint": "dns:localhost:5000"},
+            # {"url": ":5000?tls=false", "error": False, "secure": False, "scheme": "",
+            #  "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
+            # {"url": ":5000?tls=true", "error": False, "secure": True, "scheme": "",
+            #  "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
+            #
+            # # Host only
+            # {"url": "myhost", "error": False, "secure": False, "scheme": "", "host": "myhost",
+            #  "port": 443, "endpoint": "dns:myhost:443"},
+            # {"url": "myhost?tls=false", "error": False, "secure": False, "scheme": "",
+            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            # {"url": "myhost?tls=true", "error": False, "secure": True, "scheme": "",
+            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            #
+            # # Host and port
+            # {"url": "myhost:443", "error": False, "secure": False, "scheme": "", "host": "myhost",
+            #  "port": 443, "endpoint": "dns:myhost:443"},
+            # {"url": "myhost:443?tls=false", "error": False, "secure": False, "scheme": "",
+            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            # {"url": "myhost:443?tls=true", "error": False, "secure": True, "scheme": "",
+            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
 
-        testcases = [{"endpoint": ":5000", "scheme": "http", "host": "localhost", "port": 5000},
-                     {"endpoint": ":5000/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 5000, "tls": False},
+            # Scheme, host and port
+            {"url": "http://myhost", "error": False, "secure": False, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "http://myhost?tls=false", "error": True},
+            # We can't have both http/https and the tls query parameter
+            {"url": "http://myhost?tls=true", "error": True},
+            # We can't have both http/https and the tls query parameter
 
-                     {"endpoint": "localhost", "scheme": "http", "host": "localhost", "port": 80,
-                      "tls": False},
-                     {"endpoint": "localhost/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 80, "tls": False},
-                     {"endpoint": "localhost:5000", "scheme": "http", "host": "localhost",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "localhost:5000/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 5000, "tls": False},
+            {"url": "http://myhost:443", "error": False, "secure": False, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "http://myhost:443?tls=false", "error": True},
+            # We can't have both http/https and the tls query parameter
+            {"url": "http://myhost:443?tls=true", "error": True},
+            # We can't have both http/https and the tls query parameter
 
-                     {"endpoint": "http://localhost", "scheme": "http", "host": "localhost",
-                      "port": 80, "tls": False},
-                     {"endpoint": "http://localhost/v1/dapr", "scheme": "http", "host": "localhost",
-                      "port": 80, "tls": False},
-                     {"endpoint": "http://localhost:5000", "scheme": "http", "host": "localhost",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "http://localhost:5000/v1/dapr", "scheme": "http",
-                      "host": "localhost", "port": 5000, "tls": False},
+            {"url": "http://myhost:5000", "error": False, "secure": False, "scheme": "",
+             "host": "myhost", "port": 5000, "endpoint": "dns:myhost:5000"},
+            {"url": "http://myhost:5000?tls=false", "error": True},
+            # We can't have both http/https and the tls query parameter
+            {"url": "http://myhost:5000?tls=true", "error": True},
+            # We can't have both http/https and the tls query parameter
 
-                     {"endpoint": "https://localhost", "scheme": "https", "host": "localhost",
-                      "port": 443, "tls": True},
-                     {"endpoint": "https://localhost/v1/dapr", "scheme": "https",
-                                     "host": "localhost", "port": 443, "tls": True},
-                     {"endpoint": "https://localhost:5000", "scheme": "https", "host": "localhost",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "https://localhost:5000/v1/dapr", "scheme": "https",
-                      "host": "localhost", "port": 5000, "tls": True},
+            {"url": "https://myhost:443", "error": False, "secure": True, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "https://myhost:443?tls=false", "error": True},
+            {"url": "https://myhost:443?tls=true", "error": True},
 
-                     {"endpoint": "127.0.0.1", "scheme": "http", "host": "127.0.0.1", "port": 80, "tls": False},
-                     {"endpoint": "127.0.0.1/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80, "tls": False},
-                     {"endpoint": "127.0.0.1:5000", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "127.0.0.1:5000/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000, "tls": False},
+            # Scheme = dns
+            {"url": "dns:myhost", "error": False, "secure": False, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "dns:myhost?tls=false", "error": False, "secure": False, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "dns:myhost?tls=true", "error": False, "secure": True, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
 
-                     {"endpoint": "http://127.0.0.1", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80, "tls": False},
-                     {"endpoint": "http://127.0.0.1/v1/dapr", "scheme": "http", "host": "127.0.0.1",
-                      "port": 80, "tls": False},
-                     {"endpoint": "http://127.0.0.1:5000", "scheme": "http", "host": "127.0.0.1",
-                      "port": 5000, "tls": False}, {"endpoint": "http://127.0.0.1:5000/v1/dapr", "scheme": "http",
-                                      "host": "127.0.0.1", "port": 5000, "tls": False},
+            {"url": "dns://myhost", "error": False, "secure": False, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "dns://myhost?tls=false", "error": False, "secure": False, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "dns://myhost?tls=true", "error": False, "secure": True, "scheme": "dns",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
 
-                     {"endpoint": "https://127.0.0.1", "scheme": "https", "host": "127.0.0.1",
-                      "port": 443, "tls": True},
-                     {"endpoint": "https://127.0.0.1/v1/dapr", "scheme": "https",
-                                     "host": "127.0.0.1", "port": 443, "tls": True},
-                     {"endpoint": "https://127.0.0.1:5000", "scheme": "https", "host": "127.0.0.1",
-                      "port": 5000, "tls": True},
-                     {"endpoint": "https://127.0.0.1:5000/v1/dapr", "scheme": "https",
-                      "host": "127.0.0.1", "port": 5000, "tls": True},
+            # IPv6 addresses
+            {"url": "[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
+            {"url": "dns:[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
+            {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": True, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
 
-                     {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
-                     {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
-                     {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]:5000", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
-                     {"endpoint": "[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
+            {"url": "myhost:5000/v1/dapr", "error": True},
+            # Paths are not allowed in grpc endpoints
+            {"url": "myhost:5000/?a=1", "error": True},
+            # Query parameters are not allowed in grpc endpoints
+        ]
 
-                     {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
-                     {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 80, "tls": False},
-                     {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]:5000", "scheme": "http",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
-                     {"endpoint": "http://[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "http", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": False},
-
-                     {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]", "scheme": "https",
-                      "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443, "tls": True},
-                     {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]/v1/dapr",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 443, "tls": True},
-                     {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": True},
-                     {"endpoint": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000/v1/dapr",
-                      "scheme": "https", "host": "2001:db8:1f70::999:de8:7648:6e8", "port": 5000, "tls": True},
-
-                     {"endpoint": "domain.com", "scheme": "http", "host": "domain.com", "port": 80, "tls": False},
-                     {"endpoint": "domain.com/v1/grpc", "scheme": "http", "host": "domain.com",
-                      "port": 80, "tls": False},
-                     {"endpoint": "domain.com:5000", "scheme": "http", "host": "domain.com",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "domain.com:5000/v1/dapr", "scheme": "http", "host": "domain.com",
-                      "port": 5000, "tls": False},
-
-                     {"endpoint": "http://domain.com", "scheme": "http", "host": "domain.com",
-                      "port": 80, "tls": False},
-                     {"endpoint": "http://domain.com/v1/dapr", "scheme": "http",
-                                    "host": "domain.com", "port": 80, "tls": False},
-                     {"endpoint": "http://domain.com:5000", "scheme": "http", "host": "domain.com",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "http://domain.com:5000/v1/dapr", "scheme": "http",
-                      "host": "domain.com", "port": 5000, "tls": False},
-
-                     {"endpoint": "https://domain.com", "scheme": "https", "host": "domain.com",
-                      "port": 443, "tls": True},
-                     {"endpoint": "https://domain.com/v1/dapr", "scheme": "https",
-                                     "host": "domain.com", "port": 443, "tls": True},
-                     {"endpoint": "https://domain.com:5000", "scheme": "https",
-                      "host": "domain.com", "port": 5000, "tls": True},
-                     {"endpoint": "https://domain.com:5000/v1/dapr", "scheme": "https",
-                      "host": "domain.com", "port": 5000, "tls": True},
-
-                     {"endpoint": "abc.domain.com", "scheme": "http", "host": "abc.domain.com",
-                      "port": 80, "tls": False},
-                     {"endpoint": "abc.domain.com/v1/grpc", "scheme": "http",
-                                    "host": "abc.domain.com", "port": 80, "tls": False},
-                     {"endpoint": "abc.domain.com:5000", "scheme": "http", "host": "abc.domain.com",
-                      "port": 5000, "tls": False},
-                     {"endpoint": "abc.domain.com:5000/v1/dapr", "scheme": "http",
-                                      "host": "abc.domain.com", "port": 5000, "tls": False},
-
-                     {"endpoint": "http://abc.domain.com/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 80, "tls": False},
-                     {"endpoint": "http://abc.domain.com/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 80, "tls": False},
-                     {"endpoint": "http://abc.domain.com:5000/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 5000, "tls": False},
-                     {"endpoint": "http://abc.domain.com:5000/v1/dapr/v1/dapr", "scheme": "http",
-                      "host": "abc.domain.com", "port": 5000, "tls": False},
-
-                     {"endpoint": "https://abc.domain.com/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 443, "tls": True},
-                     {"endpoint": "https://abc.domain.com/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 443, "tls": True},
-                     {"endpoint": "https://abc.domain.com:5000/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 5000, "tls": True},
-                     {"endpoint": "https://abc.domain.com:5000/v1/dapr/v1/dapr", "scheme": "https",
-                      "host": "abc.domain.com", "port": 5000, "tls": True},
-
-                     ]
-
+        print(f'URL \t endpoint\t  hostname \t port \t secure \t error')
         for testcase in testcases:
-            print(testcase["endpoint"])
-            o = parse_http_endpoint(testcase["endpoint"])
-
-            self.assertEqual(testcase["scheme"], o["scheme"])
-            self.assertEqual(testcase["host"], o["hostname"])
-            self.assertEqual(testcase["port"], o["port"])
+            if testcase["error"]:
+                with self.assertRaises(ValueError):
+                    parse_grpc_endpoint(testcase["url"])
+            else:
+                endpoint = parse_grpc_endpoint(testcase["url"])
+                print(
+                    f'{testcase["url"]}\t {endpoint.get_endpoint()} \t{endpoint.get_hostname()}\t{endpoint.get_port()}\t{endpoint.is_secure()}')
+                assert testcase["endpoint"] == endpoint.get_endpoint()
+                assert testcase["secure"] == endpoint.is_secure()
+                assert testcase["host"] == endpoint.get_hostname()
+                assert str(testcase["port"]) == endpoint.get_port()

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -114,6 +114,10 @@ class DaprClientHelpersTests(unittest.TestCase):
             # Invalid addresses (with path and queries)
             {"url": "host:5000/v1/dapr", "error": True},  # Paths are not allowed in grpc endpoints
             {"url": "host:5000/?a=1", "error": True},  # Query params not allowed in grpc endpoints
+
+            # Invalid scheme
+            {"url": "inv-scheme://myhost", "error": True},
+            {"url": "inv-scheme:myhost:5000", "error": True},
         ]
 
         for testcase in testcases:
@@ -121,8 +125,8 @@ class DaprClientHelpersTests(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     GrpcEndpoint(testcase["url"])
             else:
-                endpoint = GrpcEndpoint(testcase["url"])
-                assert endpoint.get_endpoint() == testcase["endpoint"]
-                assert endpoint.is_secure() == testcase["secure"]
-                assert endpoint.get_hostname() == testcase["host"]
-                assert endpoint.get_port() == str(testcase["port"])
+                url = GrpcEndpoint(testcase["url"])
+                assert url.endpoint == testcase["endpoint"]
+                assert url.tls == testcase["secure"]
+                assert url.hostname == testcase["host"]
+                assert url.port == str(testcase["port"])

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -95,9 +95,11 @@ class DaprClientHelpersTests(unittest.TestCase):
              "scheme": "unix", "host": "my.sock", "port": "", "endpoint": "unix-abstract:my.sock"},
 
             # Vsock
-            {"url": "vsock:mycid:5000", "error": False, "secure": False, "scheme": "unix",
+            {"url": "vsock:mycid", "error": False, "secure": False, "scheme": "vsock",
+             "host": "mycid", "port": "443", "endpoint": "vsock:mycid:443"},
+            {"url": "vsock:mycid:5000", "error": False, "secure": False, "scheme": "vsock",
              "host": "mycid", "port": 5000, "endpoint": "vsock:mycid:5000"},
-            {"url": "vsock:mycid:5000?tls=true", "error": False, "secure": True, "scheme": "unix",
+            {"url": "vsock:mycid:5000?tls=true", "error": False, "secure": True, "scheme": "vsock",
              "host": "mycid", "port": 5000, "endpoint": "vsock:mycid:5000"},
 
             # IPv6 addresses

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -123,9 +123,9 @@ class DaprClientHelpersTests(unittest.TestCase):
             {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": True,
              "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 443,
              "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
-            {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000", "error": False, "secure": True,
-             "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 5000,
-             "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000"},
+            {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000", "error": False,
+             "secure": True, "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]",
+             "port": 5000, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000"},
 
             # Invalid addresses (with path and queries)
             {"url": "host:5000/v1/dapr", "error": True},  # Paths are not allowed in grpc endpoints

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from dapr.conf.helpers import parse_endpoint, parse_grpc_endpoint
+from dapr.conf.helpers import parse_grpc_endpoint
 
 
 class DaprClientHelpersTests(unittest.TestCase):
@@ -8,28 +8,28 @@ class DaprClientHelpersTests(unittest.TestCase):
     def test_parse_grpc_endpoint(self):
         testcases = [
             # Port only
-            # {"url": ":5000", "error": False, "secure": False, "scheme": "", "host": "localhost",
-            #  "port": 5000, "endpoint": "dns:localhost:5000"},
-            # {"url": ":5000?tls=false", "error": False, "secure": False, "scheme": "",
-            #  "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
-            # {"url": ":5000?tls=true", "error": False, "secure": True, "scheme": "",
-            #  "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
-            #
-            # # Host only
-            # {"url": "myhost", "error": False, "secure": False, "scheme": "", "host": "myhost",
-            #  "port": 443, "endpoint": "dns:myhost:443"},
-            # {"url": "myhost?tls=false", "error": False, "secure": False, "scheme": "",
-            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
-            # {"url": "myhost?tls=true", "error": False, "secure": True, "scheme": "",
-            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
-            #
-            # # Host and port
-            # {"url": "myhost:443", "error": False, "secure": False, "scheme": "", "host": "myhost",
-            #  "port": 443, "endpoint": "dns:myhost:443"},
-            # {"url": "myhost:443?tls=false", "error": False, "secure": False, "scheme": "",
-            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
-            # {"url": "myhost:443?tls=true", "error": False, "secure": True, "scheme": "",
-            #  "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": ":5000", "error": False, "secure": False, "scheme": "", "host": "localhost",
+             "port": 5000, "endpoint": "dns:localhost:5000"},
+            {"url": ":5000?tls=false", "error": False, "secure": False, "scheme": "",
+             "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
+            {"url": ":5000?tls=true", "error": False, "secure": True, "scheme": "",
+             "host": "localhost", "port": 5000, "endpoint": "dns:localhost:5000"},
+
+            # Host only
+            {"url": "myhost", "error": False, "secure": False, "scheme": "", "host": "myhost",
+             "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "myhost?tls=false", "error": False, "secure": False, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "myhost?tls=true", "error": False, "secure": True, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+
+            # Host and port
+            {"url": "myhost:443", "error": False, "secure": False, "scheme": "", "host": "myhost",
+             "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "myhost:443?tls=false", "error": False, "secure": False, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
+            {"url": "myhost:443?tls=true", "error": False, "secure": True, "scheme": "",
+             "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
 
             # Scheme, host and port
             {"url": "http://myhost", "error": False, "secure": False, "scheme": "",
@@ -73,19 +73,34 @@ class DaprClientHelpersTests(unittest.TestCase):
             {"url": "dns://myhost?tls=true", "error": False, "secure": True, "scheme": "dns",
              "host": "myhost", "port": 443, "endpoint": "dns:myhost:443"},
 
+            # Unix sockets
+            {"url": "unix://my.sock", "error": False, "secure": False, "scheme": "unix",
+             "host": "my.sock", "port": "", "endpoint": "unix://my.sock"},
+            {"url": "unix://my.sock?tls=true", "error": False, "secure": True, "scheme": "unix",
+             "host": "my.sock", "port": "", "endpoint": "unix://my.sock"},
+
+
             # IPv6 addresses
             {"url": "[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
             {"url": "dns:[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
             {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": True, "scheme": "", "host":"[2001:db8:1f70::999:de8:7648:6e8]", "port": 443, "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
 
-            {"url": "myhost:5000/v1/dapr", "error": True},
-            # Paths are not allowed in grpc endpoints
-            {"url": "myhost:5000/?a=1", "error": True},
-            # Query parameters are not allowed in grpc endpoints
+            # Invalid addresses (with path and queries)
+            {"url": "host:5000/v1/dapr", "error": True},  # Paths are not allowed in grpc endpoints
+            {"url": "host:5000/?a=1", "error": True},  # Query params not allowed in grpc endpoints
         ]
 
-        print(f'URL \t endpoint\t  hostname \t port \t secure \t error')
         for testcase in testcases:
+            try:
+                endpoint = parse_grpc_endpoint(testcase["url"])
+                print(f'{testcase["url"]}\t {endpoint.get_endpoint()} \t{endpoint.get_hostname()}\t{endpoint.get_port()}\t{endpoint.is_secure()}')
+                assert endpoint.get_endpoint() == testcase["endpoint"]
+                assert endpoint.is_secure() == testcase["secure"]
+                assert endpoint.get_hostname() == testcase["host"]
+                assert endpoint.get_port() == str(testcase["port"])
+            except ValueError as error:
+                print(f'{testcase["url"]}\t {error}')
+
             if testcase["error"]:
                 with self.assertRaises(ValueError):
                     parse_grpc_endpoint(testcase["url"])
@@ -93,7 +108,7 @@ class DaprClientHelpersTests(unittest.TestCase):
                 endpoint = parse_grpc_endpoint(testcase["url"])
                 print(
                     f'{testcase["url"]}\t {endpoint.get_endpoint()} \t{endpoint.get_hostname()}\t{endpoint.get_port()}\t{endpoint.is_secure()}')
-                assert testcase["endpoint"] == endpoint.get_endpoint()
-                assert testcase["secure"] == endpoint.is_secure()
-                assert testcase["host"] == endpoint.get_hostname()
-                assert str(testcase["port"]) == endpoint.get_port()
+                assert endpoint.get_endpoint() == testcase["endpoint"]
+                assert endpoint.is_secure() == testcase["secure"]
+                assert endpoint.get_hostname() == testcase["host"]
+                assert endpoint.get_port() == str(testcase["port"])

--- a/tests/conf/helpers_test.py
+++ b/tests/conf/helpers_test.py
@@ -102,16 +102,30 @@ class DaprClientHelpersTests(unittest.TestCase):
             {"url": "vsock:mycid:5000?tls=true", "error": False, "secure": True, "scheme": "vsock",
              "host": "mycid", "port": 5000, "endpoint": "vsock:mycid:5000"},
 
-            # IPv6 addresses
+            # IPv6 addresses with dns scheme
             {"url": "[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False,
              "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 443,
              "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
             {"url": "dns:[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": False,
              "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 443,
              "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
+            {"url": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000", "error": False, "secure": False,
+             "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 5000,
+             "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000"},
+            {"url": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000?abc=[]", "error": True},
+
+            # IPv6 addresses with dns scheme and authority
+            {"url": "dns://myauthority:53/[2001:db8:1f70::999:de8:7648:6e8]", "error": False,
+             "secure": False, "scheme": "dns", "host": "[2001:db8:1f70::999:de8:7648:6e8]",
+             "port": 443, "endpoint": "dns://myauthority:53/[2001:db8:1f70::999:de8:7648:6e8]:443"},
+
+            # IPv6 addresses with https scheme
             {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]", "error": False, "secure": True,
              "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 443,
              "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:443"},
+            {"url": "https://[2001:db8:1f70::999:de8:7648:6e8]:5000", "error": False, "secure": True,
+             "scheme": "", "host": "[2001:db8:1f70::999:de8:7648:6e8]", "port": 5000,
+             "endpoint": "dns:[2001:db8:1f70::999:de8:7648:6e8]:5000"},
 
             # Invalid addresses (with path and queries)
             {"url": "host:5000/v1/dapr", "error": True},  # Paths are not allowed in grpc endpoints
@@ -123,12 +137,21 @@ class DaprClientHelpersTests(unittest.TestCase):
         ]
 
         for testcase in testcases:
-            if testcase["error"]:
-                with self.assertRaises(ValueError):
-                    GrpcEndpoint(testcase["url"])
-            else:
+            # if testcase["error"]:
+            #     with self.assertRaises(ValueError):
+            #         GrpcEndpoint(testcase["url"])
+            # else:
+            #     url = GrpcEndpoint(testcase["url"])
+            #     assert url.endpoint == testcase["endpoint"]
+            #     assert url.tls == testcase["secure"]
+            #     assert url.hostname == testcase["host"]
+            #     assert url.port == str(testcase["port"])
+            try:
                 url = GrpcEndpoint(testcase["url"])
+                print(f'{testcase["url"]}\t {url.endpoint} \t{url.hostname}\t{url.port}\t{url.tls}')
                 assert url.endpoint == testcase["endpoint"]
                 assert url.tls == testcase["secure"]
                 assert url.hostname == testcase["host"]
                 assert url.port == str(testcase["port"])
+            except ValueError as error:
+                print(f'{testcase["url"]}\t \t\t\t\t Error: {error}')


### PR DESCRIPTION
# Description
This PR updates the python-sdk so it satisfies the requirements for gRPC endpoint parsing added in https://github.com/dapr/proposals/pull/40.

It also adds support for all URIs that the [gRPC name resolution](https://github.com/grpc/grpc/blob/master/doc/naming.md) document defines, including dns links with authority, unix paths with absolute and relative sockets, unix-abstract and virtual sockets.

Backwards compatibility has been maintained for endpoints where tls was inferred based on the scheme `https`.

## Issue reference
https://github.com/dapr/python-sdk/issues/619

## Checklist

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
