### PR TITLE
Update durabletask dependency in dapr-ext-workflow

### DIFF
--- a/ext/dapr-ext-workflow/setup.cfg
+++ b/ext/dapr-ext-workflow/setup.cfg
@@ -25,7 +25,7 @@ packages = find_namespace:
 include_package_data = True
 install_requires =
     dapr-dev >= 1.11.0rc1.dev
-    durabletask >= 0.1.0a3
+    durabletask >= 0.1.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
# Description

Updating the Workflow SDK library to reference the latest [durabletask](https://pypi.org/project/durabletask/) library as a dependency.

## Issue reference

Fixes https://github.com/dapr/python-sdk/issues/627 (via https://github.com/microsoft/durabletask-python/pull/21)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
