### PR TITLE
Update Workflow State JSON serialization

### DIFF
--- a/ext/dapr-ext-workflow/dapr/ext/workflow/workflow_state.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/workflow_state.py
@@ -69,5 +69,9 @@ class WorkflowState:
             'serialized_input': self.__obj.serialized_input,
             'serialized_output': self.__obj.serialized_output,
             'serialized_custom_status': self.__obj.serialized_custom_status,
-            'failure_details': self.__obj.failure_details
+            'failure_details': {
+                'message': self.__obj.failure_details.message,
+                'error_type': self.__obj.failure_details.error_type,
+                'stack_trace': self.__obj.failure_details.stack_trace
+            }
         }


### PR DESCRIPTION
# Description

Serializes the `failure_details` correctly as part of the workflow state json serialization.

Fixes #624