### PR TITLE
Fixes examples

### DIFF
--- a/examples/invoke-custom-data/README.md
+++ b/examples/invoke-custom-data/README.md
@@ -88,7 +88,6 @@ name: Shutdown dapr
 -->
 
 ```bash
-dapr stop --app-id invoke-caller
 dapr stop --app-id invoke-receiver
 ```
 

--- a/examples/w3c-tracing/README.md
+++ b/examples/w3c-tracing/README.md
@@ -329,7 +329,6 @@ name: Shutdown dapr
 -->
 
 ```bash
-dapr stop --app-id invoke-caller
 dapr stop --app-id invoke-receiver
 ```
 


### PR DESCRIPTION
# Description

While validating the 1.13 rc1 I ran into the following  3 issues:

- `./validate.sh invoke-custom-data` (❌  failed to stop app id invoke-caller: couldn't find app id invoke-caller)

- `./validate.sh w3c-tracing` (❌  failed to stop app id invoke-caller: couldn't find app id invoke-caller)

- `./validate.sh demo_workflow` (❌  details = "error starting workflow 'hello_world_wf': unable to start workflow: failed to start orchestration: error from internal actor: an active workflow with ID 'exampleInstanceID' already exists"
== APP ==   debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:50001 {created_time:"2024-02-14T14:14:09.774273+00:00", grpc_status:13, grpc_message:"error starting workflow \'hello_world_wf\': unable to start workflow: failed to start orchestration: error from internal actor: an active workflow with ID \'exampleInstanceID\' already exists"}")

This PR addresses the first two issues. The reason for this is a change of behaviour in Dapr, which now properly catches `SIGTERM` signals. The examples use `dapr run` to run the apps and the dapr cli sends a `SIGTERM` when an application finishes execution. That's why the tests broke now.

I updated them to not try to stop the dapr instance explicitly.

## Checklist

* [X] Code compiles correctly
* [X] Created/updated tests
