### PR TITLE
Updates ruff config for 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ target-version = "py38"
 line-length = 100
 fix = true
 extend-exclude = [".github", "dapr/proto"]
+[tool.ruff.lint]
 select = [
   "E",  # pycodestyle errors
   "W",  # pycodestyle warnings


### PR DESCRIPTION
# Description

In [0.2.2](https://github.com/astral-sh/ruff/releases/tag/v0.2.2) Ruff made some changes in the way project.toml needs to be structured. This PR addresses that.
