### PR TITLE
Release SDK 1.13

### DIFF
--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -1535,6 +1535,12 @@ class DaprGrpcClientAsync:
         Args:
             timeout_s (float): timeout in seconds
         """
+        warn(
+            'The wait method is deprecated. A health check is now done automatically on client '
+            'initialization.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         start = time.time()
         while True:

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -1518,6 +1518,12 @@ class DaprGrpcClient:
         Args:
             timeout_s (float): timeout in seconds
         """
+        warn(
+            'The wait method is deprecated. A health check is now done automatically on client '
+            'initialization.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
         start = time.time()
         while True:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/dapr/version/version.py
+++ b/dapr/version/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.13.0rc1'
+__version__ = '1.13.0'

--- a/examples/invoke-simple/requirements.txt
+++ b/examples/invoke-simple/requirements.txt
@@ -1,2 +1,2 @@
 dapr-ext-grpc >= 1.12.0
-dapr >= 1.13.0rc1
+dapr >= 1.13.0

--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -1,5 +1,5 @@
 dapr-ext-grpc >= 1.12.0
-dapr >= 1.13.0rc1
+dapr >= 1.13.0
 opentelemetry-sdk
 opentelemetry-instrumentation-grpc
 opentelemetry-exporter-zipkin

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.13.0rc1'
+__version__ = '1.13.0'

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.13.0rc1
+    dapr >= 1.13.0
     uvicorn >= 0.11.6
     fastapi >= 0.60.1
 

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.13.0rc1'
+__version__ = '1.13.0'

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.13.0rc1
+    dapr >= 1.13.0
     cloudevents >= 1.0.0
 
 [options.packages.find]

--- a/ext/dapr-ext-workflow/setup.cfg
+++ b/ext/dapr-ext-workflow/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.8
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.13.0rc1
+    dapr >= 1.13.0
     durabletask >= 0.1.1a1
 
 [options.packages.find]

--- a/ext/flask_dapr/flask_dapr/version.py
+++ b/ext/flask_dapr/flask_dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.13.0rc1'
+__version__ = '1.13.0'

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -26,4 +26,4 @@ include_package_data = true
 zip_safe = false
 install_requires =
     Flask >= 1.1
-    dapr >= 1.13.0rc1
+    dapr >= 1.13.0


### PR DESCRIPTION
# Description

Release SDK 1.13.0
-[x] All dependencies do not use the `-dev` name (e.g. we do not use `dapr-dev` or `dapr-ext-grpc-dev`)

This was done previously for the RC. When we cut a release branch we have to switch from the main branch builds (`-dev`) packages, to our real release packages.

```
grep -rol "dapr\-dev" . --include "setup.cfg" --include "requirements.txt" --include "Readme.md" --include "README.md" --exclude-dir ".tox" | xargs sed -i '' "s/dapr\-dev/dapr/g"
grep -rol "dapr\-ext\-workflow\-dev" . --include "setup.cfg" --include "requirements.txt" --exclude-dir ".tox" | xargs sed -i '' "s/dapr\-ext\-workflow\-dev/dapr\-ext\-workflow/g"
```

We have to do the same for any examples that use `dapr-ext-grpc`, `dapr-ext-fastapi` and `flask_dapr`.

-[x] Version updated from RC version to release version

This command happens to work right now, but be careful not to update packages which didn't get a version bump (like `dapr-ext-grpc` and `dapr-ext-fastapi` and `flask_dapr`)

```bash
export OLD="1\.13\.0rc1" && export NEW="1\.13\.0" && grep -rol "$OLD" . --include "version.py" --include "setup.cfg" --include "requirements.txt" --include "Readme.md" --include "README.md" --exclude-dir ".tox" | xargs sed -i '' "s/$OLD/$NEW/"
```

The release will only occur after we push a tag, but the version used comes from the source files - not the tag.

Different tags trigger releases:
`workflow-v*` like `workflow-v0.4.0` triggers the workflow SDK release (this is already released)
`grpc-v*` triggers the `dapr-ext-grpc`release - this is not necessary at this time since we are not releasing this.
Same for `fastapi-v*` and `flask-v*`.

We only will push the `v*` style tag (here `v1.13.0`) for the regular SDK release to be triggered.
