### PR TITLE
fix: convert DAPR_HEALTH_TIMEOUT to float

### DIFF
--- a/dapr/clients/health.py
+++ b/dapr/clients/health.py
@@ -28,7 +28,7 @@ class DaprHealth:
         headers = {USER_AGENT_HEADER: DAPR_USER_AGENT}
         if settings.DAPR_API_TOKEN is not None:
             headers[DAPR_API_TOKEN_HEADER] = settings.DAPR_API_TOKEN
-        timeout = settings.DAPR_HEALTH_TIMEOUT
+        timeout = float(settings.DAPR_HEALTH_TIMEOUT)
 
         start = time.time()
         while True:

--- a/tests/clients/test_heatlhcheck.py
+++ b/tests/clients/test_heatlhcheck.py
@@ -62,7 +62,7 @@ class DaprHealthCheckTests(unittest.TestCase):
         self.assertIn('Dapr-api-token', headers)
         self.assertEqual(headers['Dapr-api-token'], 'mytoken')
 
-    @patch.object(settings, 'DAPR_HEALTH_TIMEOUT', '2')
+    @patch.object(settings, 'DAPR_HEALTH_TIMEOUT', '2.5')
     @patch('urllib.request.urlopen')
     def test_wait_until_ready_timeout(self, mock_urlopen):
         mock_urlopen.return_value.__enter__.return_value = MagicMock(status=500)
@@ -72,5 +72,5 @@ class DaprHealthCheckTests(unittest.TestCase):
         with self.assertRaises(TimeoutError):
             DaprHealth.wait_until_ready()
 
-        self.assertGreaterEqual(time.time() - start, 2)
+        self.assertGreaterEqual(time.time() - start, 2.5)
         self.assertGreater(mock_urlopen.call_count, 1)

--- a/tests/clients/test_heatlhcheck.py
+++ b/tests/clients/test_heatlhcheck.py
@@ -62,7 +62,7 @@ class DaprHealthCheckTests(unittest.TestCase):
         self.assertIn('Dapr-api-token', headers)
         self.assertEqual(headers['Dapr-api-token'], 'mytoken')
 
-    @patch.object(settings, 'DAPR_HEALTH_TIMEOUT', 2)
+    @patch.object(settings, 'DAPR_HEALTH_TIMEOUT', '2')
     @patch('urllib.request.urlopen')
     def test_wait_until_ready_timeout(self, mock_urlopen):
         mock_urlopen.return_value.__enter__.return_value = MagicMock(status=500)


### PR DESCRIPTION
# Description

Convert settings.DAPR_HEALTH_TIMEOUT from str to float
Update DaprHealthCheckTests mock so the test can catch this error


## Issue reference

Fixes #688 [BUG] DAPR_HEALTH_TIMEOUT as environment variable is not converted to numerical value

Please reference the issue this PR will close: #_[#688]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
