### PR TITLE
Removes grpc and grpcs from the accepted schemes list

### DIFF
--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -40,7 +40,9 @@ class GrpcEndpoint:
 
         if self._parsed_url.scheme in ['http', 'https']:
             self._scheme = URIParseConfig.DEFAULT_SCHEME
-            warn('http and https schemes are deprecated for grpc, use myhost?tls=false or myhost?tls=true instead')
+            warn(
+                'http and https schemes are deprecated for grpc, use myhost?tls=false or myhost?tls=true instead'
+            )
             return
 
         if self._parsed_url.scheme not in URIParseConfig.ACCEPTED_SCHEMES:

--- a/dapr/conf/helpers.py
+++ b/dapr/conf/helpers.py
@@ -7,7 +7,7 @@ class URIParseConfig:
     DEFAULT_HOSTNAME = 'localhost'
     DEFAULT_PORT = 443
     DEFAULT_AUTHORITY = ''
-    ACCEPTED_SCHEMES = ['dns', 'unix', 'unix-abstract', 'vsock', 'http', 'https', 'grpc', 'grpcs']
+    ACCEPTED_SCHEMES = ['dns', 'unix', 'unix-abstract', 'vsock', 'http', 'https']
 
 
 class GrpcEndpoint:
@@ -40,7 +40,7 @@ class GrpcEndpoint:
 
         if self._parsed_url.scheme in ['http', 'https']:
             self._scheme = URIParseConfig.DEFAULT_SCHEME
-            warn('http and https schemes are deprecated, use grpc or grpcs instead')
+            warn('http and https schemes are deprecated for grpc, use myhost?tls=false or myhost?tls=true instead')
             return
 
         if self._parsed_url.scheme not in URIParseConfig.ACCEPTED_SCHEMES:


### PR DESCRIPTION
# Description

`grpc` and `grpcs` are not valid schemes, as per the [gRPC name resolution spec](https://github.com/grpc/grpc/blob/master/doc/naming.md) and they're not included in our [test matrix](https://github.com/dapr/proposals/blob/main/20230627-S-sidecar-endpoint-tls.md#test-matrix), but they were mistakenly left over in the accepted schemes list.
