### PR TITLE
fix: update devcontainer postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
 	],
 
-	"postCreateCommand": "pip install -r ./dev-requirements.txt",
+	"postCreateCommand": ".devcontainer/postCreateCommand.sh",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,8 @@
+# Install a project in a editable mode
+pip3 install -e .
+pip3 install -e ./ext/dapr-ext-grpc/
+pip3 install -e ./ext/dapr-ext-fastapi/
+pip3 install -e ./ext/dapr-ext-workflow/
+
+# Install required packages
+pip3 install -r ./dev-requirements.txt


### PR DESCRIPTION
# Description

Refer to [dotnet-dsk](https://github.com/dapr/dotnet-sdk/blob/master/.devcontainer/devcontainer.json#L45) to add a postCreateCommand script and update devcontainer.json to run this script in postCreateCommand
When working with dev container, all tests show up in VSCode testing tab and pass successfully

![image](https://github.com/dapr/python-sdk/assets/17125956/f365c95f-1bf1-4193-988a-5b91386ffd8b)


## Issue reference

Please reference the issue this PR will close: #702

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
