### PR TITLE
Add actor state ttl support

### DIFF
--- a/dapr/actor/runtime/_state_provider.py
+++ b/dapr/actor/runtime/_state_provider.py
@@ -66,7 +66,10 @@ class StateProvider:
                 "operation": "upsert",
                 "request": {
                     "key": "key1",
-                    "value": "myData"
+                    "value": "myData",
+                    "metadata": {
+                        "ttlInSeconds": "3600"
+                    }
                 }
             },
             {
@@ -94,6 +97,11 @@ class StateProvider:
                 serialized = self._state_serializer.serialize(state.value)
                 json_output.write(b',"value":')
                 json_output.write(serialized)
+            if  state.ttl_in_seconds is not None and state.ttl_in_seconds >= 0:
+                serialized = self._state_serializer.serialize(state.ttl_in_seconds)
+                json_output.write(b',"metadata":{"ttlInSeconds":"')
+                json_output.write(serialized)
+                json_output.write(b'"}')
             json_output.write(b'}}')
             first_state = False
         json_output.write(b']')

--- a/dapr/actor/runtime/_state_provider.py
+++ b/dapr/actor/runtime/_state_provider.py
@@ -97,7 +97,7 @@ class StateProvider:
                 serialized = self._state_serializer.serialize(state.value)
                 json_output.write(b',"value":')
                 json_output.write(serialized)
-            if  state.ttl_in_seconds is not None and state.ttl_in_seconds >= 0:
+            if state.ttl_in_seconds is not None and state.ttl_in_seconds >= 0:
                 serialized = self._state_serializer.serialize(state.ttl_in_seconds)
                 json_output.write(b',"metadata":{"ttlInSeconds":"')
                 json_output.write(serialized)

--- a/dapr/actor/runtime/state_change.py
+++ b/dapr/actor/runtime/state_change.py
@@ -35,7 +35,13 @@ class StateChangeKind(Enum):
 
 
 class ActorStateChange(Generic[T]):
-    def __init__(self, state_name: str, value: T, change_kind: StateChangeKind, ttl_in_seconds: Optional[int] = None):
+    def __init__(
+        self,
+        state_name: str,
+        value: T,
+        change_kind: StateChangeKind,
+        ttl_in_seconds: Optional[int] = None,
+    ):
         self._state_name = state_name
         self._value = value
         self._change_kind = change_kind

--- a/dapr/actor/runtime/state_change.py
+++ b/dapr/actor/runtime/state_change.py
@@ -14,7 +14,7 @@ limitations under the License.
 """
 
 from enum import Enum
-from typing import TypeVar, Generic
+from typing import TypeVar, Generic, Optional
 
 T = TypeVar('T')
 
@@ -35,10 +35,11 @@ class StateChangeKind(Enum):
 
 
 class ActorStateChange(Generic[T]):
-    def __init__(self, state_name: str, value: T, change_kind: StateChangeKind):
+    def __init__(self, state_name: str, value: T, change_kind: StateChangeKind, ttl_in_seconds: Optional[int] = None):
         self._state_name = state_name
         self._value = value
         self._change_kind = change_kind
+        self._ttl_in_seconds = ttl_in_seconds
 
     @property
     def state_name(self) -> str:
@@ -51,3 +52,7 @@ class ActorStateChange(Generic[T]):
     @property
     def change_kind(self) -> StateChangeKind:
         return self._change_kind
+
+    @property
+    def ttl_in_seconds(self) -> Optional[int]:
+        return self._ttl_in_seconds

--- a/dapr/actor/runtime/state_manager.py
+++ b/dapr/actor/runtime/state_manager.py
@@ -29,7 +29,9 @@ CONTEXT: ContextVar[Optional[Dict[str, Any]]] = ContextVar('state_tracker_contex
 
 
 class StateMetadata(Generic[T]):
-    def __init__(self, value: T, change_kind: StateChangeKind, ttl_in_seconds: Optional[int] = None):
+    def __init__(
+        self, value: T, change_kind: StateChangeKind, ttl_in_seconds: Optional[int] = None
+    ):
         self._value = value
         self._change_kind = change_kind
         self._ttl_in_seconds = ttl_in_seconds
@@ -136,9 +138,13 @@ class ActorStateManager(Generic[T]):
             self._type_name, self._actor.id.id, state_name
         )
         if existed:
-            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.update, ttl_in_seconds)
+            state_change_tracker[state_name] = StateMetadata(
+                value, StateChangeKind.update, ttl_in_seconds
+            )
         else:
-            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.add, ttl_in_seconds)
+            state_change_tracker[state_name] = StateMetadata(
+                value, StateChangeKind.add, ttl_in_seconds
+            )
 
     async def remove_state(self, state_name: str) -> None:
         if not await self.try_remove_state(state_name):
@@ -247,7 +253,12 @@ class ActorStateManager(Generic[T]):
             if state_metadata.change_kind == StateChangeKind.none:
                 continue
             state_changes.append(
-                ActorStateChange(state_name, state_metadata.value, state_metadata.change_kind, state_metadata.ttl_in_seconds)
+                ActorStateChange(
+                    state_name,
+                    state_metadata.value,
+                    state_metadata.change_kind,
+                    state_metadata.ttl_in_seconds,
+                )
             )
             if state_metadata.change_kind == StateChangeKind.remove:
                 states_to_remove.append(state_name)

--- a/dapr/actor/runtime/state_manager.py
+++ b/dapr/actor/runtime/state_manager.py
@@ -247,7 +247,7 @@ class ActorStateManager(Generic[T]):
             if state_metadata.change_kind == StateChangeKind.none:
                 continue
             state_changes.append(
-                ActorStateChange(state_name, state_metadata.value, state_metadata.change_kind)
+                ActorStateChange(state_name, state_metadata.value, state_metadata.change_kind, state_metadata.ttl_in_seconds)
             )
             if state_metadata.change_kind == StateChangeKind.remove:
                 states_to_remove.append(state_name)

--- a/dapr/actor/runtime/state_manager.py
+++ b/dapr/actor/runtime/state_manager.py
@@ -29,9 +29,10 @@ CONTEXT: ContextVar[Optional[Dict[str, Any]]] = ContextVar('state_tracker_contex
 
 
 class StateMetadata(Generic[T]):
-    def __init__(self, value: T, change_kind: StateChangeKind):
+    def __init__(self, value: T, change_kind: StateChangeKind, ttl_in_seconds: Optional[int] = None):
         self._value = value
         self._change_kind = change_kind
+        self._ttl_in_seconds = ttl_in_seconds
 
     @property
     def value(self) -> T:
@@ -48,6 +49,14 @@ class StateMetadata(Generic[T]):
     @change_kind.setter
     def change_kind(self, new_kind: StateChangeKind) -> None:
         self._change_kind = new_kind
+
+    @property
+    def ttl_in_seconds(self) -> Optional[int]:
+        return self._ttl_in_seconds
+
+    @ttl_in_seconds.setter
+    def ttl_in_seconds(self, new_ttl_in_seconds: int) -> None:
+        self._ttl_in_seconds = new_ttl_in_seconds
 
 
 class ActorStateManager(Generic[T]):
@@ -103,10 +112,17 @@ class ActorStateManager(Generic[T]):
         return has_value, val
 
     async def set_state(self, state_name: str, value: T) -> None:
+        await self.set_state_ttl(state_name, value, None)
+
+    async def set_state_ttl(self, state_name: str, value: T, ttl_in_seconds: Optional[int]) -> None:
+        if ttl_in_seconds is not None and ttl_in_seconds < 0:
+            return
+
         state_change_tracker = self._get_contextual_state_tracker()
         if state_name in state_change_tracker:
             state_metadata = state_change_tracker[state_name]
             state_metadata.value = value
+            state_metadata.ttl_in_seconds = ttl_in_seconds
 
             if (
                 state_metadata.change_kind == StateChangeKind.none
@@ -120,9 +136,9 @@ class ActorStateManager(Generic[T]):
             self._type_name, self._actor.id.id, state_name
         )
         if existed:
-            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.update)
+            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.update, ttl_in_seconds)
         else:
-            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.add)
+            state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.add, ttl_in_seconds)
 
     async def remove_state(self, state_name: str) -> None:
         if not await self.try_remove_state(state_name):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,6 +13,6 @@ pyOpenSSL>=23.2.0
 # needed for type checking
 Flask>=1.1
 # needed for auto fix
-ruff===0.4.2
+ruff===0.2.2
 # needed for dapr-ext-workflow
 durabletask>=0.1.1a1

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -116,6 +116,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value1', state.value)
+        self.assertEqual(None, state.ttl_in_seconds)
 
     @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_set_state_for_existing_state_only_in_mem(self):
@@ -131,6 +132,7 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_change_tracker['state1']
         self.assertEqual(StateChangeKind.add, state.change_kind)
         self.assertEqual('value2', state.value)
+        self.assertEqual(None, state.ttl_in_seconds)
 
     @mock.patch(
         'tests.actor.fake_client.FakeDaprActorClient.get_state',
@@ -143,6 +145,73 @@ class ActorStateManagerTests(unittest.TestCase):
         state = state_change_tracker['state1']
         self.assertEqual(StateChangeKind.update, state.change_kind)
         self.assertEqual('value2', state.value)
+        self.assertEqual(None, state.ttl_in_seconds)
+
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
+    def test_set_state_ttl_for_new_state(self):
+        state_manager = ActorStateManager(self._fake_actor)
+        state_change_tracker = state_manager._get_contextual_state_tracker()
+        _run(state_manager.set_state_ttl('state1', 'value1', 3600))
+
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.add, state.change_kind)
+        self.assertEqual('value1', state.value)
+        self.assertEqual(3600, state.ttl_in_seconds)
+
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
+    def test_set_state_ttl_for_existing_state_only_in_mem(self):
+        state_manager = ActorStateManager(self._fake_actor)
+        state_change_tracker = state_manager._get_contextual_state_tracker()
+        _run(state_manager.set_state_ttl('state1', 'value1', 3600))
+
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.add, state.change_kind)
+        self.assertEqual('value1', state.value)
+        self.assertEqual(3600, state.ttl_in_seconds)
+
+        _run(state_manager.set_state_ttl('state1', 'value2', 7200))
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.add, state.change_kind)
+        self.assertEqual('value2', state.value)
+        self.assertEqual(7200, state.ttl_in_seconds)
+
+    @mock.patch(
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=b'"value1"'),
+    )
+    def test_set_state_ttl_for_existing_state(self):
+        state_manager = ActorStateManager(self._fake_actor)
+        state_change_tracker = state_manager._get_contextual_state_tracker()
+        _run(state_manager.set_state_ttl('state1', 'value2', 3600))
+
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.update, state.change_kind)
+        self.assertEqual('value2', state.value)
+        self.assertEqual(3600, state.ttl_in_seconds)
+
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
+    def test_set_state_ttl_lt_0_for_new_state(self):
+        state_manager = ActorStateManager(self._fake_actor)
+        state_change_tracker = state_manager._get_contextual_state_tracker()
+        _run(state_manager.set_state_ttl('state1', 'value1', -3600))
+        self.assertNotIn('state1', state_change_tracker)
+
+    @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
+    def test_set_state_ttl_lt_0_for_existing_state_only_in_mem(self):
+        state_manager = ActorStateManager(self._fake_actor)
+        state_change_tracker = state_manager._get_contextual_state_tracker()
+        _run(state_manager.set_state_ttl('state1', 'value1', 3600))
+
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.add, state.change_kind)
+        self.assertEqual('value1', state.value)
+        self.assertEqual(3600, state.ttl_in_seconds)
+
+        _run(state_manager.set_state_ttl('state1', 'value2', -3600))
+        state = state_change_tracker['state1']
+        self.assertEqual(StateChangeKind.add, state.change_kind)
+        self.assertEqual('value1', state.value)
+        self.assertEqual(3600, state.ttl_in_seconds)
 
     @mock.patch('tests.actor.fake_client.FakeDaprActorClient.get_state', new=_async_mock())
     def test_remove_state_for_non_existing_state(self):


### PR DESCRIPTION
# Description

This PR follows [go-sdk](https://github.com/dapr/go-sdk/pull/383)'s implementation to support actor state TTL feature
Added set_state_ttl method, updated save_state method in state_manager and added more tests
Updated state_change and state_async_provider with TTL and fix test_save_state

## Issue reference

Please reference the issue this PR will close: #560 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
