### PR TITLE
Fix Holopin alias field

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -2,4 +2,4 @@ organization: dapr
 defaultSticker: clrqfdv4x24910fl5n4iwu5oa
 stickers:
 - id: clrqfdv4x24910fl5n4iwu5oa
-  alias: { id: clrqfdv4x24910fl5n4iwu5oa, alias: sdk-badge }
+  alias: sdk-badge


### PR DESCRIPTION
# Description

The alias field of the Holopin.yml file was incorrect. This PR fixes this.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #693
