### PR TITLE
doc: document that users can self-assign issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,10 @@ A non-exclusive list of code that must be places in `vendor/`:
 
 **Thank You!** - Your contributions to open source, large or small, make projects like this possible. Thank you for taking the time to contribute.
 
+## Github Dapr Bot Commands
+
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users.
+
 ## Code of Conduct
 
 This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/dapr/community/blob/master/CODE-OF-CONDUCT.md)

--- a/daprdocs/content/en/python-sdk-contributing/python-contributing.md
+++ b/daprdocs/content/en/python-sdk-contributing/python-contributing.md
@@ -8,6 +8,10 @@ description: Guidelines for contributing to the Dapr Python SDK
 
 When contributing to the [Python SDK](https://github.com/dapr/python-sdk) the following rules and best-practices should be followed.
 
+## Github Dapr Bot Commands
+
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users.
+
 ## Examples
 
 The `examples` directory contains code samples for users to run to try out specific functionality of the various Python SDK packages and extensions. When writing new and updated samples keep in mind:

--- a/daprdocs/content/en/python-sdk-contributing/python-contributing.md
+++ b/daprdocs/content/en/python-sdk-contributing/python-contributing.md
@@ -8,10 +8,6 @@ description: Guidelines for contributing to the Dapr Python SDK
 
 When contributing to the [Python SDK](https://github.com/dapr/python-sdk) the following rules and best-practices should be followed.
 
-## Github Dapr Bot Commands
-
-Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users.
-
 ## Examples
 
 The `examples` directory contains code samples for users to run to try out specific functionality of the various Python SDK packages and extensions. When writing new and updated samples keep in mind:
@@ -25,3 +21,7 @@ The `daprdocs` directory contains the markdown files that are rendered into the 
 
    - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
    - All files and directories should be prefixed with `python-` to ensure all file/directory names are globally unique across all Dapr documentation.
+
+## Github Dapr Bot Commands
+
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users.


### PR DESCRIPTION
# Description

Refer to [js-sdk](https://github.com/dapr/js-sdk/pull/527), informs users about the GitHub daprbot commands available in the repo with doc link.

## Issue reference

Please reference the issue this PR will close: #602

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
