### PR TITLE
Fixes try_add_state in actor state manger

### DIFF
--- a/dapr/actor/runtime/state_manager.py
+++ b/dapr/actor/runtime/state_manager.py
@@ -86,7 +86,7 @@ class ActorStateManager(Generic[T]):
         existed = await self._actor.runtime_ctx.state_provider.contains_state(
             self._type_name, self._actor.id.id, state_name
         )
-        if not existed:
+        if existed:
             return False
 
         state_change_tracker[state_name] = StateMetadata(value, StateChangeKind.add)

--- a/tests/actor/test_state_manager.py
+++ b/tests/actor/test_state_manager.py
@@ -46,7 +46,7 @@ class ActorStateManagerTests(unittest.TestCase):
 
     @mock.patch(
         'tests.actor.fake_client.FakeDaprActorClient.get_state',
-        new=_async_mock(return_value=base64.b64encode(b'"value1"')),
+        new=_async_mock(),
     )
     @mock.patch(
         'tests.actor.fake_client.FakeDaprActorClient.save_state_transactionally', new=_async_mock()
@@ -64,6 +64,20 @@ class ActorStateManagerTests(unittest.TestCase):
         self.assertEqual(StateChangeKind.add, state.change_kind)
 
         # Add 'state1' again
+        added = _run(state_manager.try_add_state('state1', 'value1'))
+        self.assertFalse(added)
+
+    @mock.patch(
+        'tests.actor.fake_client.FakeDaprActorClient.get_state',
+        new=_async_mock(return_value=base64.b64encode(b'"value1"')),
+    )
+    @mock.patch(
+        'tests.actor.fake_client.FakeDaprActorClient.save_state_transactionally', new=_async_mock()
+    )
+    def test_add_state_with_existing_state(self):
+        state_manager = ActorStateManager(self._fake_actor)
+
+        # Add first 'state1'
         added = _run(state_manager.try_add_state('state1', 'value1'))
         self.assertFalse(added)
 


### PR DESCRIPTION
# Description

Fixes a bug in the behaviour of `try_add_state` in the actor state manager. Namely, the method would throw an error saying a key already exists when it doesn't.

## Issue reference

https://github.com/dapr/python-sdk/issues/755

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
