### PR TITLE
[docs] Remove alpha for workflow stable release

### DIFF
--- a/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-workflow-ext/python-workflow.md
+++ b/daprdocs/content/en/python-sdk-docs/python-sdk-extensions/python-workflow-ext/python-workflow.md
@@ -6,10 +6,6 @@ weight: 30000
 description: How to get up and running with workflows using the Dapr Python SDK
 ---
 
-{{% alert title="Note" color="primary" %}}
-Dapr Workflow is currently in alpha.
-{{% /alert %}}
-
 Let’s create a Dapr workflow and invoke it using the console. With the [provided hello world workflow example](https://github.com/dapr/python-sdk/tree/master/examples/demo_workflow), you will:
 
 - Run a [Python console application using `DaprClient`](https://github.com/dapr/python-sdk/blob/master/examples/demo_workflow/app.py)


### PR DESCRIPTION
# Description

Python docs still showed workflow in alpha. Removed for stable release.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/docs#3870

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
