### PR TITLE
Replace deprecated tox.ini option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands_pre =
 [testenv:doc]
 basepython = python3
 usedevelop = False
-whitelist_externals = make
+allowlist_externals = make
 deps = sphinx
 commands =
     sphinx-apidoc -E -o docs/actor dapr/actor


### PR DESCRIPTION
# Description

I have fixed a broken option in the `tox.ini` file. This option was replaced in 2020, deprecated, and eventually removed in tox 4. The correct option already appears elsewhere in this `tox.ini` file.

<https://tox.wiki/en/3.18.1/changelog.html#v3-18-0-2020-07-23>

This fix is necessary to run `tox -e doc` per the README.md instructions on tox version 4.

## Issue reference

Skipped due to minor nature of issue; no actual code changes.

Here was the build error from `tox -e doc`:

```
[...]
doc: commands[0]> sphinx-apidoc -E -o docs/actor dapr/actor
doc: commands[1]> sphinx-apidoc -E -o docs/clients dapr/clients
doc: commands[2]> sphinx-apidoc -E -o docs/proto dapr/proto
doc: commands[3]> sphinx-apidoc -E -o docs/serializers dapr/serializers
doc: commands[4]> make html -C docs
doc: failed with make is not allowed, use allowlist_externals to allow it
  doc: FAIL code 1 (25.60 seconds)
  evaluation failed :( (25.65 seconds)
```

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

I'm assuming all of the above are n/a -- there are no meaningful changes to the codebase itself.