### PR TITLE
Catch error in sdk when workflow instance not found

### DIFF
--- a/examples/demo_workflow/app.py
+++ b/examples/demo_workflow/app.py
@@ -139,6 +139,8 @@ def main():
 
         # Pause Test
         d.pause_workflow(instance_id=instance_id, workflow_component=workflow_component)
+        sleep(3)
+
         get_response = d.get_workflow(
             instance_id=instance_id, workflow_component=workflow_component
         )
@@ -146,6 +148,8 @@ def main():
 
         # Resume Test
         d.resume_workflow(instance_id=instance_id, workflow_component=workflow_component)
+        sleep(3)
+        
         get_response = d.get_workflow(
             instance_id=instance_id, workflow_component=workflow_component
         )

--- a/examples/demo_workflow/app.py
+++ b/examples/demo_workflow/app.py
@@ -149,7 +149,7 @@ def main():
         # Resume Test
         d.resume_workflow(instance_id=instance_id, workflow_component=workflow_component)
         sleep(3)
-        
+
         get_response = d.get_workflow(
             instance_id=instance_id, workflow_component=workflow_component
         )

--- a/examples/workflow/monitor.py
+++ b/examples/workflow/monitor.py
@@ -63,7 +63,12 @@ if __name__ == '__main__':
 
     wf_client = wf.DaprWorkflowClient()
     job_id = 'job1'
-    status = wf_client.get_workflow_state(job_id)
+    status = None
+    try:
+        status = wf_client.get_workflow_state(job_id)
+    except Exception:
+        pass
+
     if not status or status.runtime_status.name != 'RUNNING':
         # TODO update to use reuse_id_policy
         instance_id = wf_client.schedule_new_workflow(

--- a/examples/workflow/monitor.py
+++ b/examples/workflow/monitor.py
@@ -63,11 +63,7 @@ if __name__ == '__main__':
 
     wf_client = wf.DaprWorkflowClient()
     job_id = 'job1'
-    status = None
-    try:
-        status = wf_client.get_workflow_state(job_id)
-    except Exception:
-        pass
+    status = wf_client.get_workflow_state(job_id)
     if not status or status.runtime_status.name != 'RUNNING':
         # TODO update to use reuse_id_policy
         instance_id = wf_client.schedule_new_workflow(

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
@@ -139,7 +139,7 @@ class DaprWorkflowClient:
                 self._logger.warning(f"Workflow instance not found: {instance_id}")
                 return None
             self._logger.error(f"Unhandled RPC error while fetching workflow state: {error.code()} - {error.details()}")
-            raise error
+            raise
 
     def wait_for_workflow_start(
         self, instance_id: str, *, fetch_payloads: bool = False, timeout_in_seconds: int = 60

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
@@ -130,8 +130,12 @@ class DaprWorkflowClient:
             exist.
 
         """
-        state = self.__obj.get_orchestration_state(instance_id, fetch_payloads=fetch_payloads)
-        return WorkflowState(state) if state else None
+        try:
+            state = self.__obj.get_orchestration_state(instance_id, fetch_payloads=fetch_payloads)
+            return WorkflowState(state) if state else None
+        except Exception as error:
+            self._logger.error(f'Error fetching workflow state: {error}')
+            return None
 
     def wait_for_workflow_start(
         self, instance_id: str, *, fetch_payloads: bool = False, timeout_in_seconds: int = 60

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
@@ -136,9 +136,11 @@ class DaprWorkflowClient:
             return WorkflowState(state) if state else None
         except RpcError as error:
             if 'no such instance exists' in error.details():
-                self._logger.warning(f"Workflow instance not found: {instance_id}")
+                self._logger.warning(f'Workflow instance not found: {instance_id}')
                 return None
-            self._logger.error(f"Unhandled RPC error while fetching workflow state: {error.code()} - {error.details()}")
+            self._logger.error(
+                f'Unhandled RPC error while fetching workflow state: {error.code()} - {error.details()}'
+            )
             raise
 
     def wait_for_workflow_start(

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
@@ -24,6 +24,7 @@ import durabletask.internal.orchestrator_service_pb2 as pb
 from dapr.ext.workflow.workflow_state import WorkflowState
 from dapr.ext.workflow.workflow_context import Workflow
 from dapr.ext.workflow.util import getAddress
+from grpc import RpcError
 
 from dapr.clients import DaprInternalError
 from dapr.clients.http.client import DAPR_API_TOKEN_HEADER
@@ -133,9 +134,12 @@ class DaprWorkflowClient:
         try:
             state = self.__obj.get_orchestration_state(instance_id, fetch_payloads=fetch_payloads)
             return WorkflowState(state) if state else None
-        except Exception as error:
-            self._logger.error(f'Error fetching workflow state: {error}')
-            return None
+        except RpcError as error:
+            if 'no such instance exists' in error.details():
+                self._logger.warning(f"Workflow instance not found: {instance_id}")
+                return None
+            self._logger.error(f"Unhandled RPC error while fetching workflow state: {error.code()} - {error.details()}")
+            raise error
 
     def wait_for_workflow_start(
         self, instance_id: str, *, fetch_payloads: bool = False, timeout_in_seconds: int = 60

--- a/ext/dapr-ext-workflow/tests/test_workflow_client.py
+++ b/ext/dapr-ext-workflow/tests/test_workflow_client.py
@@ -21,6 +21,7 @@ from unittest import mock
 from dapr.ext.workflow.dapr_workflow_client import DaprWorkflowClient
 from durabletask import client
 import durabletask.internal.orchestrator_service_pb2 as pb
+from grpc import StatusCode, RpcError
 
 mock_schedule_result = 'workflow001'
 mock_raise_event_result = 'event001'
@@ -29,6 +30,18 @@ mock_suspend_result = 'suspend001'
 mock_resume_result = 'resume001'
 mock_purge_result = 'purge001'
 mock_instance_id = 'instance001'
+wf_exists = False
+
+class SimulatedRpcError(RpcError):
+    def __init__(self, code, details):
+        self._code = code
+        self._details = details
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
 
 
 class FakeTaskHubGrpcClient:
@@ -43,7 +56,12 @@ class FakeTaskHubGrpcClient:
         return mock_schedule_result
 
     def get_orchestration_state(self, instance_id, fetch_payloads):
+        global wf_exists
+        if not wf_exists:
+            raise SimulatedRpcError(code="UNKNOWN", details="no such instance exists")
+
         return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.PENDING)
+
 
     def wait_for_orchestration_start(self, instance_id, fetch_payloads, timeout):
         return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.RUNNING)
@@ -100,6 +118,13 @@ class WorkflowClientTest(unittest.TestCase):
             )
             assert actual_schedule_result == mock_schedule_result
 
+            actual_get_result = wfClient.get_workflow_state(instance_id=mock_instance_id,
+                fetch_payloads=True)
+            assert actual_get_result is None
+
+
+            global wf_exists
+            wf_exists = True
             actual_get_result = wfClient.get_workflow_state(
                 instance_id=mock_instance_id, fetch_payloads=True
             )

--- a/ext/dapr-ext-workflow/tests/test_workflow_client.py
+++ b/ext/dapr-ext-workflow/tests/test_workflow_client.py
@@ -21,7 +21,7 @@ from unittest import mock
 from dapr.ext.workflow.dapr_workflow_client import DaprWorkflowClient
 from durabletask import client
 import durabletask.internal.orchestrator_service_pb2 as pb
-from grpc import StatusCode, RpcError
+from grpc import RpcError
 
 mock_schedule_result = 'workflow001'
 mock_raise_event_result = 'event001'
@@ -31,6 +31,7 @@ mock_resume_result = 'resume001'
 mock_purge_result = 'purge001'
 mock_instance_id = 'instance001'
 wf_exists = False
+
 
 class SimulatedRpcError(RpcError):
     def __init__(self, code, details):
@@ -58,10 +59,9 @@ class FakeTaskHubGrpcClient:
     def get_orchestration_state(self, instance_id, fetch_payloads):
         global wf_exists
         if not wf_exists:
-            raise SimulatedRpcError(code="UNKNOWN", details="no such instance exists")
+            raise SimulatedRpcError(code='UNKNOWN', details='no such instance exists')
 
         return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.PENDING)
-
 
     def wait_for_orchestration_start(self, instance_id, fetch_payloads, timeout):
         return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.RUNNING)
@@ -118,10 +118,10 @@ class WorkflowClientTest(unittest.TestCase):
             )
             assert actual_schedule_result == mock_schedule_result
 
-            actual_get_result = wfClient.get_workflow_state(instance_id=mock_instance_id,
-                fetch_payloads=True)
+            actual_get_result = wfClient.get_workflow_state(
+                instance_id=mock_instance_id, fetch_payloads=True
+            )
             assert actual_get_result is None
-
 
             global wf_exists
             wf_exists = True

--- a/ext/dapr-ext-workflow/tests/test_workflow_client.py
+++ b/ext/dapr-ext-workflow/tests/test_workflow_client.py
@@ -30,7 +30,7 @@ mock_suspend_result = 'suspend001'
 mock_resume_result = 'resume001'
 mock_purge_result = 'purge001'
 mock_instance_id = 'instance001'
-wf_exists = False
+wf_status = 'not-found'
 
 
 class SimulatedRpcError(RpcError):
@@ -57,11 +57,15 @@ class FakeTaskHubGrpcClient:
         return mock_schedule_result
 
     def get_orchestration_state(self, instance_id, fetch_payloads):
-        global wf_exists
-        if not wf_exists:
+        global wf_status
+        if wf_status == 'not-found':
             raise SimulatedRpcError(code='UNKNOWN', details='no such instance exists')
-
-        return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.PENDING)
+        elif wf_status == 'found':
+            return self._inner_get_orchestration_state(
+                instance_id, client.OrchestrationStatus.PENDING
+            )
+        else:
+            raise SimulatedRpcError(code='UNKNOWN', details='unknown error')
 
     def wait_for_orchestration_start(self, instance_id, fetch_payloads, timeout):
         return self._inner_get_orchestration_state(instance_id, client.OrchestrationStatus.RUNNING)
@@ -118,13 +122,20 @@ class WorkflowClientTest(unittest.TestCase):
             )
             assert actual_schedule_result == mock_schedule_result
 
+            global wf_status
+            wf_status = 'not-found'
             actual_get_result = wfClient.get_workflow_state(
                 instance_id=mock_instance_id, fetch_payloads=True
             )
             assert actual_get_result is None
 
-            global wf_exists
-            wf_exists = True
+            wf_status = 'error'
+            with self.assertRaises(RpcError):
+                wfClient.get_workflow_state(instance_id=mock_instance_id, fetch_payloads=True)
+
+            assert actual_get_result is None
+
+            wf_status = 'found'
             actual_get_result = wfClient.get_workflow_state(
                 instance_id=mock_instance_id, fetch_payloads=True
             )


### PR DESCRIPTION
# Description

Catches error from daprd in the sdk when workflow instance not found, so that users don't have to do try/catch in the app.
Instead, when daprd can't find the workflow instance `get_workflow_state` will return `None`, as specified in the doc comment.

Also adds a small demo workflows examples fix.

## Issue reference

https://github.com/dapr/python-sdk/issues/745

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [x] Created/updated tests

