### PR TITLE
Fix `get_worfklow_state` docstring to match `fetch_payloads` default

### DIFF
--- a/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/dapr_workflow_client.py
@@ -123,7 +123,7 @@ class DaprWorkflowClient:
         Args:
             instanceId: The unique ID of the workflow instance to fetch.
             fetch_payloads: If true, fetches the input, output payloads and custom status
-            for the workflow instance. Defaults to false.
+            for the workflow instance. Defaults to true.
 
         Returns:
             The current state of the workflow instance, or None if the workflow instance does not


### PR DESCRIPTION
# Description

A very minor fix to the docstring of `get_workflow_state` `fetch_payloads` argument to match the default value.

The default value is not changed to make sure there is no breaking change.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #744 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
