### PR TITLE
Remove test sleep

### DIFF
--- a/examples/demo_workflow/app.py
+++ b/examples/demo_workflow/app.py
@@ -139,8 +139,6 @@ def main():
 
         # Pause Test
         d.pause_workflow(instance_id=instance_id, workflow_component=workflow_component)
-        sleep(3)
-
         get_response = d.get_workflow(
             instance_id=instance_id, workflow_component=workflow_component
         )
@@ -148,8 +146,6 @@ def main():
 
         # Resume Test
         d.resume_workflow(instance_id=instance_id, workflow_component=workflow_component)
-        sleep(3)
-
         get_response = d.get_workflow(
             instance_id=instance_id, workflow_component=workflow_component
         )


### PR DESCRIPTION
The relevant  async endpoint was converted back to sync in dapr runtime, so reverting the test change.