### PR TITLE
fix: enable better type hint support for PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ setup(
     version=version,
     description=description,
     long_description=long_description,
+    package_data={"": ["py.typed"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
     version=version,
     description=description,
     long_description=long_description,
-    package_data={"": ["py.typed"]},
+    package_data={'': ['py.typed']},
 )


### PR DESCRIPTION
# Description

This PR adds a `py.typed` marker file and updates `setup.py` to include it in `package_data`. This signals to type checkers that the package provides inline type annotations, following PEP 561. It improves type-checking support for users of the package.

For reference:
https://peps.python.org/pep-0561/#packaging-type-information
https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/

Dapr Agents repo imports this as a dependency and bc this repo is missing the `py.typed` file, then all of my python sdk imports must have `# type: ignore` comment otherwise I get an error on the import using `tox -e type` cmd...

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
