### PR TITLE
Adds a way to pull protos from a specific dapr branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The generated files will be found in `docs/_build`.
 
 ```sh
 pip3 install -r tools/requirements.txt
+export DAPR_BRANCH=release-1.16 # Optional, defaults to master
 ./tools/regen_grpcclient.sh
 ```
 

--- a/dapr/proto/README.md
+++ b/dapr/proto/README.md
@@ -13,6 +13,7 @@ Run the following commands:
 
 ```sh
 pip3 install -r tools/requirements.txt
+export DAPR_BRANCH=release-1.16 # Optional, defaults to master
 ./tools/regen_grpcclient.sh
 ```
 

--- a/tools/regen_grpcclient.sh
+++ b/tools/regen_grpcclient.sh
@@ -16,6 +16,7 @@
 # Path to store output
 PROTO_PATH="dapr/proto"
 SRC=.
+DAPR_BRANCH=${DAPR_BRANCH:-master}
 
 # Http request CLI
 HTTP_REQUEST_CLI=curl
@@ -38,7 +39,7 @@ downloadFile() {
     FILE_PATH="${PROTO_PATH}/${PKG_NAME}/v1"
 
     # URL for proto file
-    PROTO_URL="https://raw.githubusercontent.com/dapr/dapr/master/dapr/proto/${PKG_NAME}/v1/${FILE_NAME}.proto"
+    PROTO_URL="https://raw.githubusercontent.com/dapr/dapr/${DAPR_BRANCH}/dapr/proto/${PKG_NAME}/v1/${FILE_NAME}.proto"
 
     mkdir -p "${FILE_PATH}"
 


### PR DESCRIPTION
I find it useful to pull specific protos when updating proto files, as we don't always want to pull them from `master`.