### PR TITLE
Rename wait_until_ready to wait_for_sidecar

### DIFF
--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -153,7 +153,7 @@ class DaprGrpcClientAsync:
             max_grpc_message_length (int, optional): The maximum grpc send and receive
                 message length in bytes.
         """
-        DaprHealth.wait_until_ready()
+        DaprHealth.wait_for_sidecar()
         self.retry_policy = retry_policy or RetryPolicy()
 
         useragent = f'dapr-sdk-python/{__version__}'

--- a/dapr/aio/clients/grpc/subscription.py
+++ b/dapr/aio/clients/grpc/subscription.py
@@ -51,7 +51,7 @@ class Subscription:
 
     async def reconnect_stream(self):
         await self.close()
-        DaprHealth.wait_until_ready()
+        DaprHealth.wait_for_sidecar()
         print('Attempting to reconnect...')
         await self.start()
 

--- a/dapr/clients/grpc/client.py
+++ b/dapr/clients/grpc/client.py
@@ -145,7 +145,7 @@ class DaprGrpcClient:
                 message length in bytes.
             retry_policy (RetryPolicy optional): Specifies retry behaviour
         """
-        DaprHealth.wait_until_ready()
+        DaprHealth.wait_for_sidecar()
         self.retry_policy = retry_policy or RetryPolicy()
 
         useragent = f'dapr-sdk-python/{__version__}'

--- a/dapr/clients/grpc/subscription.py
+++ b/dapr/clients/grpc/subscription.py
@@ -65,7 +65,7 @@ class Subscription:
 
     def reconnect_stream(self):
         self.close()
-        DaprHealth.wait_until_ready()
+        DaprHealth.wait_for_sidecar()
         print('Attempting to reconnect...')
         self.start()
 

--- a/dapr/clients/health.py
+++ b/dapr/clients/health.py
@@ -15,6 +15,7 @@ limitations under the License.
 import urllib.request
 import urllib.error
 import time
+from warnings import warn
 
 from dapr.clients.http.conf import DAPR_API_TOKEN_HEADER, USER_AGENT_HEADER, DAPR_USER_AGENT
 from dapr.clients.http.helpers import get_api_url
@@ -24,6 +25,15 @@ from dapr.conf import settings
 class DaprHealth:
     @staticmethod
     def wait_until_ready():
+        warn(
+            'This method is deprecated. Use DaprHealth.wait_for_sidecar instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        DaprHealth.wait_for_sidecar()
+
+    @staticmethod
+    def wait_for_sidecar():
         health_url = f'{get_api_url()}/healthz/outbound'
         headers = {USER_AGENT_HEADER: DAPR_USER_AGENT}
         if settings.DAPR_API_TOKEN is not None:

--- a/dapr/clients/http/client.py
+++ b/dapr/clients/http/client.py
@@ -51,7 +51,7 @@ class DaprHttpClient:
             timeout (int, optional): Timeout in seconds, defaults to 60.
             headers_callback (lambda: Dict[str, str]], optional): Generates header for each request.
         """
-        DaprHealth.wait_until_ready()
+        DaprHealth.wait_for_sidecar()
 
         self._timeout = aiohttp.ClientTimeout(total=timeout)
         self._serializer = message_serializer

--- a/tests/clients/test_heatlhcheck.py
+++ b/tests/clients/test_heatlhcheck.py
@@ -24,13 +24,13 @@ from dapr.version import __version__
 class DaprHealthCheckTests(unittest.TestCase):
     @patch.object(settings, 'DAPR_HTTP_ENDPOINT', 'http://domain.com:3500')
     @patch('urllib.request.urlopen')
-    def test_wait_until_ready_success(self, mock_urlopen):
+    def test_wait_for_sidecar_success(self, mock_urlopen):
         mock_urlopen.return_value.__enter__.return_value = MagicMock(status=200)
 
         try:
-            DaprHealth.wait_until_ready()
+            DaprHealth.wait_for_sidecar()
         except Exception as e:
-            self.fail(f'wait_until_ready() raised an exception unexpectedly: {e}')
+            self.fail(f'wait_for_sidecar() raised an exception unexpectedly: {e}')
 
         mock_urlopen.assert_called_once()
 
@@ -45,13 +45,13 @@ class DaprHealthCheckTests(unittest.TestCase):
     @patch.object(settings, 'DAPR_HTTP_ENDPOINT', 'http://domain.com:3500')
     @patch.object(settings, 'DAPR_API_TOKEN', 'mytoken')
     @patch('urllib.request.urlopen')
-    def test_wait_until_ready_success_with_api_token(self, mock_urlopen):
+    def test_wait_for_sidecar_success_with_api_token(self, mock_urlopen):
         mock_urlopen.return_value.__enter__.return_value = MagicMock(status=200)
 
         try:
-            DaprHealth.wait_until_ready()
+            DaprHealth.wait_for_sidecar()
         except Exception as e:
-            self.fail(f'wait_until_ready() raised an exception unexpectedly: {e}')
+            self.fail(f'wait_for_sidecar() raised an exception unexpectedly: {e}')
 
         mock_urlopen.assert_called_once()
 
@@ -64,13 +64,13 @@ class DaprHealthCheckTests(unittest.TestCase):
 
     @patch.object(settings, 'DAPR_HEALTH_TIMEOUT', '2.5')
     @patch('urllib.request.urlopen')
-    def test_wait_until_ready_timeout(self, mock_urlopen):
+    def test_wait_for_sidecar_timeout(self, mock_urlopen):
         mock_urlopen.return_value.__enter__.return_value = MagicMock(status=500)
 
         start = time.time()
 
         with self.assertRaises(TimeoutError):
-            DaprHealth.wait_until_ready()
+            DaprHealth.wait_for_sidecar()
 
         self.assertGreaterEqual(time.time() - start, 2.5)
         self.assertGreater(mock_urlopen.call_count, 1)


### PR DESCRIPTION
Close https://github.com/dapr/python-sdk/issues/820

For consistency with other SDKs, renaming `wait_until_ready` to `wait_for_sidecar`.
Keeping 'old' method for retro-compatibility, with a deprecation warning.