### PR TITLE
Extend key generation time

### DIFF
--- a/examples/crypto/README.md
+++ b/examples/crypto/README.md
@@ -21,7 +21,7 @@ It creates a client using `DaprClient`, uses a local store defined in
 
 <!-- STEP
 name: Generate crypto
-timeout_seconds: 5
+timeout_seconds: 20
 -->
 
 ```bash


### PR DESCRIPTION
The `openssl genpkey` can be slow sometimes and fail due to timeout, specially on busy CPUs.

For example, this was a failed run: https://github.com/dapr/python-sdk/actions/runs/18187901961/job/51776133522

Notice the long chain of `+` and `.` and the time it took.