### PR TITLE
Fix CI - CLI version step

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -70,7 +70,7 @@ jobs:
           echo "Found $RUNTIME_VERSION"
       - name: Determine latest Dapr Cli version
         run: |
-          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases?per_page=1&page=1" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.[0].tag_name'| tr -d '",v')
+          export CLI_VERSION=$(curl "https://api.github.com/repos/dapr/cli/releases/latest" --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq '.tag_name'| tr -d '",v')
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
       - name: Set up Python ${{ matrix.python_ver }}


### PR DESCRIPTION
We're having an issue with the CI where the github API for the CLI releases at page 1 and per-page 1 is returning empty results.

The GitHub API has an endpoint to get the latest release: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release