### PR TITLE
release 1.16.1

### DIFF
--- a/dapr/version/version.py
+++ b/dapr/version/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.16.1rc1'
+__version__ = '1.16.1'

--- a/examples/demo_actor/demo_actor/requirements.txt
+++ b/examples/demo_actor/demo_actor/requirements.txt
@@ -1,1 +1,1 @@
-dapr-ext-fastapi>=1.16.1rc1
+dapr-ext-fastapi>=1.16.1

--- a/examples/demo_workflow/demo_workflow/requirements.txt
+++ b/examples/demo_workflow/demo_workflow/requirements.txt
@@ -1,1 +1,1 @@
-dapr-ext-workflow>=1.16.1rc1
+dapr-ext-workflow>=1.16.1

--- a/examples/invoke-simple/requirements.txt
+++ b/examples/invoke-simple/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-grpc >= 1.16.1rc1
-dapr >= 1.16.1rc1
+dapr-ext-grpc >= 1.16.1
+dapr >= 1.16.1

--- a/examples/w3c-tracing/requirements.txt
+++ b/examples/w3c-tracing/requirements.txt
@@ -1,5 +1,5 @@
-dapr-ext-grpc >= 1.16.1rc1
-dapr >= 1.16.1rc1
+dapr-ext-grpc >= 1.16.1
+dapr >= 1.16.1
 opentelemetry-sdk
 opentelemetry-instrumentation-grpc
 opentelemetry-exporter-zipkin

--- a/examples/workflow/requirements.txt
+++ b/examples/workflow/requirements.txt
@@ -1,2 +1,2 @@
-dapr-ext-workflow>=1.16.1rc1
-dapr>=1.16.1rc1
+dapr-ext-workflow>=1.16.1
+dapr>=1.16.1

--- a/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
+++ b/ext/dapr-ext-fastapi/dapr/ext/fastapi/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.16.1rc1'
+__version__ = '1.16.1'

--- a/ext/dapr-ext-fastapi/setup.cfg
+++ b/ext/dapr-ext-fastapi/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.9
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.16.1rc1
+    dapr >= 1.16.1
     uvicorn >= 0.11.6
     fastapi >= 0.60.1
 

--- a/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
+++ b/ext/dapr-ext-grpc/dapr/ext/grpc/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.16.1rc1'
+__version__ = '1.16.1'

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.9
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.16.1rc1
+    dapr >= 1.16.1
     cloudevents >= 1.0.0
 
 [options.packages.find]

--- a/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
+++ b/ext/dapr-ext-workflow/dapr/ext/workflow/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.16.1rc1'
+__version__ = '1.16.1'

--- a/ext/dapr-ext-workflow/setup.cfg
+++ b/ext/dapr-ext-workflow/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.9
 packages = find_namespace:
 include_package_data = True
 install_requires =
-    dapr >= 1.16.1rc1
+    dapr >= 1.16.1
     durabletask-dapr >= 0.2.0a9
 
 [options.packages.find]

--- a/ext/flask_dapr/flask_dapr/version.py
+++ b/ext/flask_dapr/flask_dapr/version.py
@@ -13,4 +13,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-__version__ = '1.16.1rc1'
+__version__ = '1.16.1'

--- a/ext/flask_dapr/setup.cfg
+++ b/ext/flask_dapr/setup.cfg
@@ -26,4 +26,4 @@ include_package_data = true
 zip_safe = false
 install_requires =
     Flask >= 1.1
-    dapr >= 1.16.1rc1
+    dapr >= 1.16.1


### PR DESCRIPTION
Promoting `1.16.1rc1` to 1.16.1.
Changes from 1.16.0: https://github.com/dapr/python-sdk/compare/workflow-v1.16.0...v1.16.1rc1
