### PR TITLE
fix(build): handle rate limiting causing failures in build

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -99,7 +99,7 @@ jobs:
           pip install setuptools wheel twine tox
       - name: Set up Dapr CLI
         run: |
-          wget -q "https://github.com/dapr/cli/releases/download/v${{ env.DAPR_CLI_VER }}/dapr_${{ env.GOARCH }}.tar.gz" -O /tmp/dapr.tar.gz
+          wget -q "https://github.com/dapr/cli/releases/download/v${{ env.DAPR_CLI_VER }}/dapr_${{ env.GOOS }}_${{ env.GOARCH }}.tar.gz" -O /tmp/dapr.tar.gz
           sudo tar xzf /tmp/dapr.tar.gz -C /usr/local/bin dapr
           dapr --version
       - name: Set up Go ${{ env.GOVER }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -66,13 +66,27 @@ jobs:
           ref: ${{ env.CHECKOUT_REF }}
       - uses: azure/setup-helm@v4
       - name: Determine latest Dapr Runtime version (including prerelease)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUNTIME_VERSION=$(curl -s "https://api.github.com/repos/dapr/dapr/releases" | sort -r | grep '"tag_name"' | head -n 1 | cut -d ':' -f2 | tr -d '",v ')
+          RUNTIME_VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/dapr/dapr/releases?per_page=10" | \
+            jq -r 'sort_by(.created_at) | reverse | .[0].tag_name | ltrimstr("v")')
+          if [ -z "$RUNTIME_VERSION" ] || [ "$RUNTIME_VERSION" = "null" ]; then
+            echo "Failed to resolve Dapr Runtime version" && exit 1
+          fi
           echo "DAPR_RUNTIME_VER=$RUNTIME_VERSION" >> $GITHUB_ENV
           echo "Found $RUNTIME_VERSION"
-      - name: Determine latest Dapr Cli version (including prerelease)
+      - name: Determine latest Dapr CLI version (including prerelease)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CLI_VERSION=$(curl -s "https://api.github.com/repos/dapr/cli/releases" | sort -r | grep '"tag_name"' | head -n 1 | cut -d ':' -f2 | tr -d '",v ')
+          CLI_VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/dapr/cli/releases?per_page=10" | \
+            jq -r 'sort_by(.created_at) | reverse | .[0].tag_name | ltrimstr("v")')
+          if [ -z "$CLI_VERSION" ] || [ "$CLI_VERSION" = "null" ]; then
+            echo "Failed to resolve Dapr CLI version" && exit 1
+          fi
           echo "DAPR_CLI_VER=$CLI_VERSION" >> $GITHUB_ENV
           echo "Found $CLI_VERSION"
       - name: Set up Python ${{ matrix.python_ver }}
@@ -84,7 +98,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine tox
       - name: Set up Dapr CLI
-        run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+        run: |
+          wget -q "https://github.com/dapr/cli/releases/download/v${{ env.DAPR_CLI_VER }}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
+          sudo tar xzf /tmp/dapr.tar.gz -C /usr/local/bin dapr
+          dapr --version
       - name: Set up Go ${{ env.GOVER }}
         if: env.DAPR_REF != '' || env.DAPR_CLI_REF != ''
         uses: actions/setup-go@v5

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -99,7 +99,7 @@ jobs:
           pip install setuptools wheel twine tox
       - name: Set up Dapr CLI
         run: |
-          wget -q "https://github.com/dapr/cli/releases/download/v${{ env.DAPR_CLI_VER }}/dapr_linux_amd64.tar.gz" -O /tmp/dapr.tar.gz
+          wget -q "https://github.com/dapr/cli/releases/download/v${{ env.DAPR_CLI_VER }}/dapr_${{ env.GOARCH }}.tar.gz" -O /tmp/dapr.tar.gz
           sudo tar xzf /tmp/dapr.tar.gz -C /usr/local/bin dapr
           dapr --version
       - name: Set up Go ${{ env.GOVER }}

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -69,7 +69,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RUNTIME_VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+          RUNTIME_VERSION=$(curl -fsS -H "Authorization: Bearer $GITHUB_TOKEN" \
             "https://api.github.com/repos/dapr/dapr/releases?per_page=10" | \
             jq -r 'sort_by(.created_at) | reverse | .[0].tag_name | ltrimstr("v")')
           if [ -z "$RUNTIME_VERSION" ] || [ "$RUNTIME_VERSION" = "null" ]; then
@@ -81,7 +81,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CLI_VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" \
+          CLI_VERSION=$(curl -fsS -H "Authorization: Bearer $GITHUB_TOKEN" \
             "https://api.github.com/repos/dapr/cli/releases?per_page=10" | \
             jq -r 'sort_by(.created_at) | reverse | .[0].tag_name | ltrimstr("v")')
           if [ -z "$CLI_VERSION" ] || [ "$CLI_VERSION" = "null" ]; then


### PR DESCRIPTION
# Description

There have been several PRs such as this one with 3.14 failing the build on the validation of the quickstarts: https://github.com/dapr/python-sdk/actions/runs/23053657978/job/66961073927

This is because curl fetches the latest version and gets rate-limited since this is unathenticated calls, and then DAPR_CLI_VER is an empty string, which yields the broken zip URL of `download//dapr_linux_amd64.tar.gz`.

This PR makes the curl authenticated which should increase our rate limits and use proper json parsing with jq and more reliable checks for proper installation.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
