### PR TITLE
chore: Remove helm from examples validation

### DIFF
--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -64,7 +64,6 @@ jobs:
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}
-      - uses: azure/setup-helm@v4
       - name: Determine latest Dapr Runtime version (including prerelease)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ext/dapr-ext-grpc/setup.cfg
+++ b/ext/dapr-ext-grpc/setup.cfg
@@ -25,7 +25,7 @@ packages = find_namespace:
 include_package_data = True
 install_requires =
     dapr >= 1.17.0.dev
-    cloudevents >= 1.0.0
+    cloudevents >= 1.0.0, < 2.0.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
This workflow doesn't use helm. I guess is some left over from previous versions where dapr was installed using helm.

Also fixes the CI by filtering `cloudevents < 2.0.0`, which just got released and it breaks the grpc extension.