### PR TITLE
Use single `v*` tags to release

### DIFF
--- a/.github/workflows/build-tag.yaml
+++ b/.github/workflows/build-tag.yaml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - v*
-      - workflow-v*
-      - grpc-v*
-      - flask-v*
-      - fastapi-v*
-      - langgraph-v*
-      - strands-v*
   workflow_dispatch:
 
 jobs:
@@ -79,14 +73,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine tox
     - name: Build and publish Dapr Python SDK
-      if: startsWith(github.ref_name, 'v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish dapr-ext-workflow
-      if: startsWith(github.ref_name, 'workflow-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
@@ -94,7 +86,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish Dapr Flask Extension
-      if: startsWith(github.ref_name, 'flask-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
@@ -102,7 +93,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish dapr-ext-grpc
-      if: startsWith(github.ref_name, 'grpc-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
@@ -110,7 +100,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish dapr-ext-fastapi
-      if: startsWith(github.ref_name, 'fastapi-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
@@ -118,7 +107,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish dapr-ext-langgraph
-      if: startsWith(github.ref_name, 'langgraph-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |
@@ -126,7 +114,6 @@ jobs:
         python setup.py sdist bdist_wheel
         twine upload dist/*
     - name: Build and publish dapr-ext-strands
-      if: startsWith(github.ref_name, 'strands-v')
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_UPLOAD_PASS }}
       run: |

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -22,12 +22,6 @@ on:
       - feature/*
     tags:
       - v*
-      - workflow-v*
-      - grpc-v*
-      - flask-v*
-      - fastapi-v*
-      - langgraph-v*
-      - strands-v*
   pull_request:
     branches:
       - main

--- a/.github/workflows/validate_examples.yaml
+++ b/.github/workflows/validate_examples.yaml
@@ -7,12 +7,6 @@ on:
       - feature/*
     tags:
       - v*
-      - workflow-v*
-      - grpc-v*
-      - fastapi-v*
-      - flask-v*
-      - langgraph-v*
-      - strands-v*
   pull_request:
     branches:
       - main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ MyPy is configured to check: `dapr/actor/`, `dapr/clients/`, `dapr/conf/`, `dapr
 - **DCO required**: Every commit must include a `Signed-off-by` line. Use `git commit -s` to add it automatically.
 - **CI checks**: Linting (ruff), unit tests (Python 3.10-3.14), type checking (mypy), and DCO verification run on all PRs.
 - **Branch targets**: PRs go to `main` or `release-*` branches.
-- **Tag-based releases**: Tags like `v*`, `workflow-v*`, `grpc-v*`, `fastapi-v*`, `flask-v*`, `langgraph-v*`, `strands-v*` trigger PyPI publishing for the corresponding package.
+- **Tag-based releases**: A single `v*` tag triggers PyPI publishing for all packages (core SDK and all extensions).
 
 ## Agent task checklist
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,21 @@
 # Release process
 
 This document describes the release process for the Dapr Python SDK.
-It covers all packages published from this repository:
 
-| Tag prefix | PyPI package |
-|---|---|
-| `v*` | `dapr` (core SDK) |
-| `workflow-v*` | `dapr-ext-workflow` |
-| `grpc-v*` | `dapr-ext-grpc` |
-| `fastapi-v*` | `dapr-ext-fastapi` |
-| `flask-v*` | `flask_dapr` |
-| `langgraph-v*` | `dapr-ext-langgraph` |
-| `strands-v*` | `dapr-ext-strands` |
+A single tag (`v*`) triggers the release of **all packages** published from this repository:
+
+| PyPI package |
+|---|
+| `dapr` (core SDK) |
+| `dapr-ext-workflow` |
+| `dapr-ext-grpc` |
+| `dapr-ext-fastapi` |
+| `flask_dapr` |
+| `dapr-ext-langgraph` |
+| `dapr-ext-strands` |
+
+You can also create the tag via a **GitHub Release**, which auto-creates the tag and provides
+a changelog UI.
 
 ## Overview
 
@@ -102,26 +106,20 @@ Open a PR targeting `main` to align it with the new release version:
 - In all seven version files: change the previous dev version to `X.Y.0.dev`
 - In all six extension `setup.cfg` files: change the previous `dapr >= ...dev` to `dapr >= X.Y.0.dev`
 
-### 4. Push the tags
+### 4. Push the tag
 
-Once the version bump PR on `release-X.Y` is merged, create and push the tags from the
+Once the version bump PR on `release-X.Y` is merged, create and push the tag from the
 **tip of `release-X.Y`**:
 
 ```bash
 git checkout release-X.Y
 git pull upstream release-X.Y
 
-git tag vX.Y.0rc0            && git push upstream vX.Y.0rc0
-git tag workflow-vX.Y.0rc0   && git push upstream workflow-vX.Y.0rc0
-git tag grpc-vX.Y.0rc0       && git push upstream grpc-vX.Y.0rc0
-git tag flask-vX.Y.0rc0      && git push upstream flask-vX.Y.0rc0
-git tag fastapi-vX.Y.0rc0    && git push upstream fastapi-vX.Y.0rc0
-git tag langgraph-vX.Y.0rc0  && git push upstream langgraph-vX.Y.0rc0
-git tag strands-vX.Y.0rc0    && git push upstream strands-vX.Y.0rc0
+git tag vX.Y.0rc0 && git push upstream vX.Y.0rc0
 ```
 
-Each tag push triggers the `dapr-python-release` workflow which builds and uploads the
-corresponding package to PyPI.
+The tag push triggers the `dapr-python-release` workflow which builds and uploads
+all packages to PyPI.
 
 ## Scenario B — Ship a new release candidate
 
@@ -134,7 +132,7 @@ Open a PR **targeting `release-X.Y`** that does:
 - In all seven version files: change `X.Y.0rc(N-1)` → `X.Y.0rcN`
 - In all six extension `setup.cfg` files: change `dapr >= X.Y.0rc(N-1)` → `dapr >= X.Y.0rcN`
 
-### 2. Push the tags
+### 2. Push the tag
 
 Once the PR is merged:
 
@@ -142,13 +140,7 @@ Once the PR is merged:
 git checkout release-X.Y
 git pull upstream release-X.Y
 
-git tag vX.Y.0rcN            && git push upstream vX.Y.0rcN
-git tag workflow-vX.Y.0rcN   && git push upstream workflow-vX.Y.0rcN
-git tag grpc-vX.Y.0rcN       && git push upstream grpc-vX.Y.0rcN
-git tag flask-vX.Y.0rcN      && git push upstream flask-vX.Y.0rcN
-git tag fastapi-vX.Y.0rcN    && git push upstream fastapi-vX.Y.0rcN
-git tag langgraph-vX.Y.0rcN  && git push upstream langgraph-vX.Y.0rcN
-git tag strands-vX.Y.0rcN    && git push upstream strands-vX.Y.0rcN
+git tag vX.Y.0rcN && git push upstream vX.Y.0rcN
 ```
 
 ## Scenario C — Ship the stable release (and patch releases)
@@ -163,7 +155,7 @@ Open a PR **targeting `release-X.Y`** that does:
 - In all seven version files: change `X.Y.ZrcN` → `X.Y.Z` (drop the `rcN` suffix)
 - In all six extension `setup.cfg` files: change `dapr >= X.Y.ZrcN` → `dapr >= X.Y.Z`
 
-### 2. Push the tags
+### 2. Push the tag
 
 Once the PR is merged:
 
@@ -171,14 +163,11 @@ Once the PR is merged:
 git checkout release-X.Y
 git pull upstream release-X.Y
 
-git tag vX.Y.Z            && git push upstream vX.Y.Z
-git tag workflow-vX.Y.Z   && git push upstream workflow-vX.Y.Z
-git tag grpc-vX.Y.Z       && git push upstream grpc-vX.Y.Z
-git tag flask-vX.Y.Z      && git push upstream flask-vX.Y.Z
-git tag fastapi-vX.Y.Z    && git push upstream fastapi-vX.Y.Z
-git tag langgraph-vX.Y.Z  && git push upstream langgraph-vX.Y.Z
-git tag strands-vX.Y.Z    && git push upstream strands-vX.Y.Z
+git tag vX.Y.Z && git push upstream vX.Y.Z
 ```
+
+Alternatively, create a **GitHub Release** targeting `release-X.Y` with tag `vX.Y.Z` — this
+creates the tag and triggers the publish workflow automatically.
 
 ## Backporting changes
 


### PR DESCRIPTION
Close https://github.com/dapr/python-sdk/issues/969

Simplifies release process by using only a single `v*` tag instead of a tag per ext package.

With this, we can trigger releases using github releases.