### PR TITLE
Fix builds for 1.16 backport of drain_ongoing_call_timeout=None

### DIFF
--- a/dapr/clients/grpc/_helpers.py
+++ b/dapr/clients/grpc/_helpers.py
@@ -63,7 +63,7 @@ def unpack(data: GrpcAny, message: GrpcMessage) -> None:
     """
     if not isinstance(message, GrpcMessage):
         raise ValueError('output message is not protocol buffer message object')
-    if not data.Is(message.DESCRIPTOR):
+    if not data.Is(message.DESCRIPTOR):  # type: ignore[arg-type]
         raise ValueError(f'invalid type. serialized message type: {data.type_url}')
     data.Unpack(message)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ wheel
 opentelemetry-sdk
 opentelemetry-instrumentation-grpc
 httpx>=0.24
-pyOpenSSL>=23.2.0
+pyOpenSSL>=23.2.0,<26.2
 # needed for type checking
 Flask>=1.1
 # needed for auto fix


### PR DESCRIPTION
Should fix the builds in https://github.com/dapr/python-sdk/pull/1018
