### PR TITLE
fix(ext-workflow): honor DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES on workflow channels

### DIFF
--- a/dapr/ext/workflow/aio/dapr_workflow_client.py
+++ b/dapr/ext/workflow/aio/dapr_workflow_client.py
@@ -28,7 +28,7 @@ from dapr.conf.helpers import GrpcEndpoint
 from dapr.ext.workflow._durabletask import client
 from dapr.ext.workflow._durabletask.aio import client as aioclient
 from dapr.ext.workflow.logger import Logger, LoggerOptions
-from dapr.ext.workflow.util import getAddress
+from dapr.ext.workflow.util import get_grpc_channel_options, getAddress
 from dapr.ext.workflow.workflow_context import Workflow
 from dapr.ext.workflow.workflow_state import WorkflowState
 
@@ -49,7 +49,17 @@ class DaprWorkflowClient:
         host: Optional[str] = None,
         port: Optional[str] = None,
         logger_options: Optional[LoggerOptions] = None,
+        max_grpc_message_length: Optional[int] = None,
     ):
+        """Initializes the async workflow client.
+
+        Args:
+            max_grpc_message_length: Maximum gRPC message size in bytes for the
+                workflow channel, applied symmetrically to both send and receive
+                directions. Precedence: this kwarg, then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
+                gRPC default (4 MiB) when neither is set.
+        """
         address = getAddress(host, port)
 
         try:
@@ -63,6 +73,7 @@ class DaprWorkflowClient:
         if settings.DAPR_API_TOKEN:
             metadata = ((DAPR_API_TOKEN_HEADER, settings.DAPR_API_TOKEN),)
         options = self._logger.get_options()
+        channel_options = get_grpc_channel_options(max_grpc_message_length)
         self.__obj = aioclient.AsyncTaskHubGrpcClient(
             host_address=uri.endpoint,
             metadata=metadata,
@@ -70,6 +81,7 @@ class DaprWorkflowClient:
             log_handler=options.log_handler,
             log_formatter=options.log_formatter,
             interceptors=[DaprClientTimeoutInterceptorAsync()],
+            channel_options=channel_options,
         )
 
     async def schedule_new_workflow(

--- a/dapr/ext/workflow/aio/dapr_workflow_client.py
+++ b/dapr/ext/workflow/aio/dapr_workflow_client.py
@@ -54,11 +54,16 @@ class DaprWorkflowClient:
         """Initializes the async workflow client.
 
         Args:
+            host: Dapr sidecar gRPC hostname. Defaults to
+                ``settings.DAPR_RUNTIME_HOST`` (or ``DAPR_GRPC_ENDPOINT`` when set).
+            port: Dapr sidecar gRPC port. Defaults to ``settings.DAPR_GRPC_PORT``.
+            logger_options: Configuration for the client's internal logger.
             max_grpc_message_length: Maximum gRPC message size in bytes for the
                 workflow channel, applied symmetrically to both send and receive
-                directions. Precedence: this kwarg, then the
-                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
-                gRPC default (4 MiB) when neither is set.
+                directions. Precedence: this kwarg (if non-zero), then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var (if non-zero),
+                then the gRPC default (4 MiB). ``0`` in either source means
+                "no opinion" and falls through to the next source.
         """
         address = getAddress(host, port)
 

--- a/dapr/ext/workflow/dapr_workflow_client.py
+++ b/dapr/ext/workflow/dapr_workflow_client.py
@@ -27,7 +27,7 @@ from dapr.conf import settings
 from dapr.conf.helpers import GrpcEndpoint
 from dapr.ext.workflow._durabletask import client
 from dapr.ext.workflow.logger import Logger, LoggerOptions
-from dapr.ext.workflow.util import getAddress
+from dapr.ext.workflow.util import get_grpc_channel_options, getAddress
 from dapr.ext.workflow.workflow_context import Workflow
 from dapr.ext.workflow.workflow_state import WorkflowState
 
@@ -51,7 +51,17 @@ class DaprWorkflowClient:
         host: Optional[str] = None,
         port: Optional[str] = None,
         logger_options: Optional[LoggerOptions] = None,
+        max_grpc_message_length: Optional[int] = None,
     ):
+        """Initializes the sync workflow client.
+
+        Args:
+            max_grpc_message_length: Maximum gRPC message size in bytes for the
+                workflow channel, applied symmetrically to both send and receive
+                directions. Precedence: this kwarg, then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
+                gRPC default (4 MiB) when neither is set.
+        """
         address = getAddress(host, port)
 
         try:
@@ -65,6 +75,7 @@ class DaprWorkflowClient:
         if settings.DAPR_API_TOKEN:
             metadata = ((DAPR_API_TOKEN_HEADER, settings.DAPR_API_TOKEN),)
         options = self._logger.get_options()
+        channel_options = get_grpc_channel_options(max_grpc_message_length)
         self.__obj = client.TaskHubGrpcClient(
             host_address=uri.endpoint,
             metadata=metadata,
@@ -72,6 +83,7 @@ class DaprWorkflowClient:
             log_handler=options.log_handler,
             log_formatter=options.log_formatter,
             interceptors=[DaprClientTimeoutInterceptor()],
+            channel_options=channel_options,
         )
 
     def schedule_new_workflow(

--- a/dapr/ext/workflow/dapr_workflow_client.py
+++ b/dapr/ext/workflow/dapr_workflow_client.py
@@ -56,11 +56,16 @@ class DaprWorkflowClient:
         """Initializes the sync workflow client.
 
         Args:
+            host: Dapr sidecar gRPC hostname. Defaults to
+                ``settings.DAPR_RUNTIME_HOST`` (or ``DAPR_GRPC_ENDPOINT`` when set).
+            port: Dapr sidecar gRPC port. Defaults to ``settings.DAPR_GRPC_PORT``.
+            logger_options: Configuration for the client's internal logger.
             max_grpc_message_length: Maximum gRPC message size in bytes for the
                 workflow channel, applied symmetrically to both send and receive
-                directions. Precedence: this kwarg, then the
-                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
-                gRPC default (4 MiB) when neither is set.
+                directions. Precedence: this kwarg (if non-zero), then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var (if non-zero),
+                then the gRPC default (4 MiB). ``0`` in either source means
+                "no opinion" and falls through to the next source.
         """
         address = getAddress(host, port)
 

--- a/dapr/ext/workflow/util.py
+++ b/dapr/ext/workflow/util.py
@@ -38,8 +38,8 @@ def get_grpc_channel_options(
         A sequence of ``(option, value)`` tuples setting both send and receive
         limits, or ``None`` when no limit is configured.
     """
-    size = max_grpc_message_length or settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES or None
-    if size is None:
+    size = max_grpc_message_length or settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES
+    if not size:
         return None
     return [
         ('grpc.max_send_message_length', size),

--- a/dapr/ext/workflow/util.py
+++ b/dapr/ext/workflow/util.py
@@ -23,16 +23,22 @@ def get_grpc_channel_options(
 ) -> Optional[Sequence[tuple[str, Any]]]:
     """Resolves gRPC channel options for the workflow message-size limit.
 
-    Resolution order: the explicit ``max_grpc_message_length`` kwarg, then
-    ``settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES``, else ``None``.
+    Precedence: explicit ``max_grpc_message_length`` kwarg (if non-zero),
+    else ``settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` (if non-zero),
+    else the gRPC default. A ``0`` in either source is interpreted as
+    "no opinion / use default" and falls through to the next source — this
+    matches ``global_settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES = 0``
+    being the documented "unset" sentinel.
 
     Sets BOTH send and receive limits symmetrically because workflow activity
-    payloads cross the channel in both directions. ``None`` is returned when no
-    limit is configured, preserving the gRPC default behavior.
+    payloads cross the channel in both directions. Returns ``None`` when no
+    explicit limit is configured so callers leave the channel unconfigured and
+    the gRPC default applies.
 
     Args:
-        max_grpc_message_length: Explicit max gRPC message size in bytes. Takes
-            precedence over the env-var setting when truthy.
+        max_grpc_message_length: Explicit max gRPC message size in bytes.
+            ``0`` or ``None`` means "no opinion" and falls through to the
+            env var.
 
     Returns:
         A sequence of ``(option, value)`` tuples setting both send and receive

--- a/dapr/ext/workflow/util.py
+++ b/dapr/ext/workflow/util.py
@@ -13,9 +13,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 from dapr.conf import settings
+
+
+def get_grpc_channel_options(
+    max_grpc_message_length: Optional[int] = None,
+) -> Optional[Sequence[tuple[str, Any]]]:
+    """Resolves gRPC channel options for the workflow message-size limit.
+
+    Resolution order: the explicit ``max_grpc_message_length`` kwarg, then
+    ``settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES``, else ``None``.
+
+    Sets BOTH send and receive limits symmetrically because workflow activity
+    payloads cross the channel in both directions. ``None`` is returned when no
+    limit is configured, preserving the gRPC default behavior.
+
+    Args:
+        max_grpc_message_length: Explicit max gRPC message size in bytes. Takes
+            precedence over the env-var setting when truthy.
+
+    Returns:
+        A sequence of ``(option, value)`` tuples setting both send and receive
+        limits, or ``None`` when no limit is configured.
+    """
+    size = max_grpc_message_length or settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES or None
+    if size is None:
+        return None
+    return [
+        ('grpc.max_send_message_length', size),
+        ('grpc.max_receive_message_length', size),
+    ]
 
 
 def getAddress(host: Optional[str] = None, port: Optional[str] = None) -> str:

--- a/dapr/ext/workflow/workflow_runtime.py
+++ b/dapr/ext/workflow/workflow_runtime.py
@@ -123,11 +123,29 @@ class WorkflowRuntime:
         """Initializes the workflow runtime.
 
         Args:
+            host: Dapr sidecar gRPC hostname. Defaults to
+                ``settings.DAPR_RUNTIME_HOST`` (or ``DAPR_GRPC_ENDPOINT`` when set).
+            port: Dapr sidecar gRPC port. Defaults to ``settings.DAPR_GRPC_PORT``.
+            logger_options: Configuration for the runtime's internal logger.
+            interceptors: Additional client gRPC interceptors. The built-in
+                ``DaprClientTimeoutInterceptor`` is always appended after these.
+            maximum_concurrent_activity_work_items: Maximum number of activity
+                work items the worker dispatches concurrently. ``None`` lets the
+                durabletask worker pick a default.
+            maximum_concurrent_orchestration_work_items: Maximum number of
+                orchestration work items the worker dispatches concurrently.
+                ``None`` lets the durabletask worker pick a default.
+            maximum_thread_pool_workers: Size of the worker's thread pool for
+                executing sync activities. ``None`` lets the durabletask worker
+                pick a default.
+            worker_ready_timeout: Seconds to wait in :meth:`start` for the
+                worker's gRPC stream to be ready. Defaults to 30s.
             max_grpc_message_length: Maximum gRPC message size in bytes for the
                 workflow channel, applied symmetrically to both send and receive
-                directions. Precedence: this kwarg, then the
-                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
-                gRPC default (4 MiB) when neither is set.
+                directions. Precedence: this kwarg (if non-zero), then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var (if non-zero),
+                then the gRPC default (4 MiB). ``0`` in either source means
+                "no opinion" and falls through to the next source.
         """
         self._logger = Logger('WorkflowRuntime', logger_options)
         self._worker_ready_timeout = 30.0 if worker_ready_timeout is None else worker_ready_timeout

--- a/dapr/ext/workflow/workflow_runtime.py
+++ b/dapr/ext/workflow/workflow_runtime.py
@@ -29,7 +29,7 @@ from dapr.ext.workflow._durabletask import task, worker
 from dapr.ext.workflow._durabletask.internal.shared import is_async_callable as _is_async_callable
 from dapr.ext.workflow.dapr_workflow_context import DaprWorkflowContext
 from dapr.ext.workflow.logger import Logger, LoggerOptions
-from dapr.ext.workflow.util import getAddress
+from dapr.ext.workflow.util import get_grpc_channel_options, getAddress
 from dapr.ext.workflow.workflow_activity_context import Activity, WorkflowActivityContext
 from dapr.ext.workflow.workflow_context import Workflow
 
@@ -118,7 +118,17 @@ class WorkflowRuntime:
         maximum_concurrent_orchestration_work_items: Optional[int] = None,
         maximum_thread_pool_workers: Optional[int] = None,
         worker_ready_timeout: Optional[float] = None,
+        max_grpc_message_length: Optional[int] = None,
     ):
+        """Initializes the workflow runtime.
+
+        Args:
+            max_grpc_message_length: Maximum gRPC message size in bytes for the
+                workflow channel, applied symmetrically to both send and receive
+                directions. Precedence: this kwarg, then the
+                ``DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`` env var, then the
+                gRPC default (4 MiB) when neither is set.
+        """
         self._logger = Logger('WorkflowRuntime', logger_options)
         self._worker_ready_timeout = 30.0 if worker_ready_timeout is None else worker_ready_timeout
 
@@ -137,6 +147,7 @@ class WorkflowRuntime:
         if interceptors:
             all_interceptors.extend(interceptors)
         all_interceptors.append(DaprClientTimeoutInterceptor())
+        channel_options = get_grpc_channel_options(max_grpc_message_length)
         self.__worker = worker.TaskHubGrpcWorker(
             host_address=uri.endpoint,
             metadata=metadata,
@@ -144,6 +155,7 @@ class WorkflowRuntime:
             log_handler=options.log_handler,
             log_formatter=options.log_formatter,
             interceptors=all_interceptors,
+            channel_options=channel_options,
             concurrency_options=worker.ConcurrencyOptions(
                 maximum_concurrent_activity_work_items=maximum_concurrent_activity_work_items,
                 maximum_concurrent_orchestration_work_items=maximum_concurrent_orchestration_work_items,

--- a/tests/ext/workflow/test_workflow_client.py
+++ b/tests/ext/workflow/test_workflow_client.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 from grpc import RpcError
 
+from dapr.conf import settings
 from dapr.ext.workflow._durabletask import client
 from dapr.ext.workflow.dapr_workflow_client import DaprWorkflowClient
 from dapr.ext.workflow.dapr_workflow_context import DaprWorkflowContext
@@ -125,6 +126,62 @@ class WorkflowClientTimeoutInterceptorTest(unittest.TestCase):
             from dapr.clients.grpc.interceptors import DaprClientTimeoutInterceptor
 
             self.assertIsInstance(interceptors[0], DaprClientTimeoutInterceptor)
+
+
+class WorkflowClientChannelOptionsTest(unittest.TestCase):
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_explicit_kwarg_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.client.TaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_env_var_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.client.TaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient()
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 16 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 16 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_kwarg_takes_precedence_over_env_var(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.client.TaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_neither_set_passes_none(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.client.TaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient()
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertIsNone(channel_options)
 
 
 class WorkflowClientTest(unittest.TestCase):

--- a/tests/ext/workflow/test_workflow_client_aio.py
+++ b/tests/ext/workflow/test_workflow_client_aio.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 from grpc.aio import AioRpcError
 
+from dapr.conf import settings
 from dapr.ext.workflow._durabletask import client
 from dapr.ext.workflow.aio import DaprWorkflowClient
 from dapr.ext.workflow.dapr_workflow_context import DaprWorkflowContext
@@ -126,6 +127,62 @@ class WorkflowClientAioTimeoutInterceptorTest(unittest.IsolatedAsyncioTestCase):
             from dapr.aio.clients.grpc.interceptors import DaprClientTimeoutInterceptorAsync
 
             self.assertIsInstance(interceptors[0], DaprClientTimeoutInterceptorAsync)
+
+
+class WorkflowClientAioChannelOptionsTest(unittest.TestCase):
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_explicit_kwarg_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.aio.client.AsyncTaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_env_var_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.aio.client.AsyncTaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient()
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 16 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 16 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_kwarg_takes_precedence_over_env_var(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.aio.client.AsyncTaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_neither_set_passes_none(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.aio.client.AsyncTaskHubGrpcClient'
+        ) as mock_client_cls:
+            DaprWorkflowClient()
+            channel_options = mock_client_cls.call_args[1]['channel_options']
+            self.assertIsNone(channel_options)
 
 
 class WorkflowClientAioTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/ext/workflow/test_workflow_runtime.py
+++ b/tests/ext/workflow/test_workflow_runtime.py
@@ -20,6 +20,7 @@ from unittest import mock
 import grpc
 from pydantic import BaseModel, ValidationError
 
+from dapr.conf import settings
 from dapr.ext.workflow.dapr_workflow_context import DaprWorkflowContext
 from dapr.ext.workflow.workflow_activity_context import WorkflowActivityContext
 from dapr.ext.workflow.workflow_runtime import WorkflowRuntime, alternate_name
@@ -830,3 +831,63 @@ class PydanticInputCoercionTest(unittest.TestCase):
         wrapper = self.fake_registry._activity_fns['optional_no_default_act']
 
         self.assertIsNone(wrapper(mock.MagicMock(), None))
+
+
+class WorkflowRuntimeChannelOptionsTest(unittest.TestCase):
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_explicit_kwarg_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.worker.TaskHubGrpcWorker'
+        ) as mock_worker_cls:
+            WorkflowRuntime(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_worker_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_env_var_sets_symmetric_channel_options(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.worker.TaskHubGrpcWorker'
+        ) as mock_worker_cls:
+            WorkflowRuntime()
+            channel_options = mock_worker_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 16 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 16 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_kwarg_takes_precedence_over_env_var(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.worker.TaskHubGrpcWorker'
+        ) as mock_worker_cls:
+            WorkflowRuntime(max_grpc_message_length=8 * 1024 * 1024)
+            channel_options = mock_worker_cls.call_args[1]['channel_options']
+            self.assertEqual(
+                [
+                    ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                    ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+                ],
+                channel_options,
+            )
+
+    @mock.patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_neither_set_passes_none(self):
+        with mock.patch(
+            'dapr.ext.workflow._durabletask.worker.TaskHubGrpcWorker'
+        ) as mock_worker_cls:
+            WorkflowRuntime()
+            channel_options = mock_worker_cls.call_args[1]['channel_options']
+            self.assertIsNone(channel_options)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ext/workflow/test_workflow_util.py
+++ b/tests/ext/workflow/test_workflow_util.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from dapr.conf import settings
-from dapr.ext.workflow.util import getAddress
+from dapr.ext.workflow.util import get_grpc_channel_options, getAddress
 
 
 class DaprWorkflowUtilTest(unittest.TestCase):
@@ -27,3 +27,42 @@ class DaprWorkflowUtilTest(unittest.TestCase):
     @patch.object(settings, 'DAPR_GRPC_ENDPOINT', 'https://domain1.com:5000')
     def test_get_address_with_env_variable(self):
         self.assertEqual('https://domain1.com:5000', getAddress())
+
+
+class GetGrpcChannelOptionsTest(unittest.TestCase):
+    @patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_explicit_kwarg_sets_both_directions(self):
+        options = get_grpc_channel_options(8 * 1024 * 1024)
+        self.assertEqual(
+            [
+                ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+            ],
+            options,
+        )
+
+    @patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_env_var_sets_both_directions(self):
+        options = get_grpc_channel_options()
+        self.assertEqual(
+            [
+                ('grpc.max_send_message_length', 16 * 1024 * 1024),
+                ('grpc.max_receive_message_length', 16 * 1024 * 1024),
+            ],
+            options,
+        )
+
+    @patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 16 * 1024 * 1024)
+    def test_kwarg_takes_precedence_over_env_var(self):
+        options = get_grpc_channel_options(8 * 1024 * 1024)
+        self.assertEqual(
+            [
+                ('grpc.max_send_message_length', 8 * 1024 * 1024),
+                ('grpc.max_receive_message_length', 8 * 1024 * 1024),
+            ],
+            options,
+        )
+
+    @patch.object(settings, 'DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES', 0)
+    def test_neither_set_returns_none(self):
+        self.assertIsNone(get_grpc_channel_options())


### PR DESCRIPTION
# Description

Long-running workflows whose activity results exceed gRPC's 4 MiB default fail with
`RESOURCE_EXHAUSTED: Sent message larger than max (X vs. 4194304)`. #1024 added
`DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES` and threaded it through the Dapr **API**
channel only — it did not cover the **workflow** (durabletask) channel, so even with
the env var exported, workflows still hit the 4 MiB ceiling once the orchestration
history (input + accumulated activity results) crossed the limit.

This PR mirrors the #1024 pattern in `dapr-ext-workflow`:

- Adds a `get_grpc_channel_options()` helper in `dapr/ext/workflow/util.py`. Resolution
  order: explicit `max_grpc_message_length` kwarg → `settings.DAPR_GRPC_MAX_INBOUND_MESSAGE_SIZE_BYTES`
  → `None` (gRPC default).
- Threads a new optional `max_grpc_message_length: Optional[int] = None` kwarg through
  the three workflow gRPC constructors and passes the resolved `channel_options`:
  - `WorkflowRuntime.__init__` → `TaskHubGrpcWorker`
  - `DaprWorkflowClient.__init__` (sync) → `TaskHubGrpcClient`
  - `aio.DaprWorkflowClient.__init__` (async) → `AsyncTaskHubGrpcClient`
- Updates the public docstrings of all three constructors to document the kwarg and its
  precedence.

Unlike #1024, the limit is applied **symmetrically** to both send and receive, because
workflow activity payloads cross the channel in both directions (worker → daprd carries
activity output too); #1024 only set the receive limit in its env-var branch.

No new environment variable is introduced (reuses #1024's), and no vendored
`_durabletask/` internals or `dapr/proto/` files are touched.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1084

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
