### PR TITLE
Pass per-operation StateItem metadata in async execute_state_transaction

### DIFF
--- a/dapr/aio/clients/grpc/client.py
+++ b/dapr/aio/clients/grpc/client.py
@@ -1028,6 +1028,7 @@ class DaprGrpcClientAsync:
                     key=o.key,
                     value=to_bytes(o.data) if o.data is not None else to_bytes(''),
                     etag=common_v1.Etag(value=o.etag) if o.etag is not None else None,
+                    metadata=o.metadata,
                 ),
             )
             for o in operations

--- a/tests/clients/fake_dapr_server.py
+++ b/tests/clients/fake_dapr_server.py
@@ -23,6 +23,7 @@ class FakeDaprSidecar(api_service_v1.DaprServicer):
         self._http_server = FakeHttpServer(self.http_port)  # Needed for the healthcheck endpoint
         api_service_v1.add_DaprServicer_to_server(self, self._grpc_server)
         self.store = {}
+        self.transaction_operation_metadata: Dict[str, Dict[str, str]] = {}
         self.shutdown_received = False
         self.locks_to_owner = {}  # (store_name, resource_id) -> lock_owner
         self.metadata: Dict[str, str] = {}
@@ -284,7 +285,11 @@ class FakeDaprSidecar(api_service_v1.DaprServicer):
 
         headers = ()
         trailers = ()
+        self.transaction_operation_metadata = {}
         for operation in request.operations:
+            self.transaction_operation_metadata[operation.request.key] = dict(
+                operation.request.metadata
+            )
             if operation.operationType == 'delete':
                 del self.store[operation.request.key]
             else:

--- a/tests/clients/test_dapr_grpc_client.py
+++ b/tests/clients/test_dapr_grpc_client.py
@@ -562,11 +562,19 @@ class DaprGrpcClientTests(unittest.TestCase):
         dapr.execute_state_transaction(
             store_name='statestore',
             operations=[
-                TransactionalStateOperation(key=key, data=value, etag='foo'),
+                TransactionalStateOperation(
+                    key=key, data=value, etag='foo', metadata={'outbox.projection': 'true'}
+                ),
                 TransactionalStateOperation(key=another_key, data=another_value),
             ],
             transactional_metadata={'metakey': 'metavalue'},
         )
+
+        self.assertEqual(
+            self._fake_dapr_server.transaction_operation_metadata[key],
+            {'outbox.projection': 'true'},
+        )
+        self.assertEqual(self._fake_dapr_server.transaction_operation_metadata[another_key], {})
 
         resp = dapr.get_bulk_state(store_name='statestore', keys=[key, another_key])
         self.assertEqual(resp.items[0].key, key)

--- a/tests/clients/test_dapr_grpc_client_async.py
+++ b/tests/clients/test_dapr_grpc_client_async.py
@@ -577,11 +577,19 @@ class DaprGrpcClientAsyncTests(unittest.IsolatedAsyncioTestCase):
         await dapr.execute_state_transaction(
             store_name='statestore',
             operations=[
-                TransactionalStateOperation(key=key, data=value, etag='foo'),
+                TransactionalStateOperation(
+                    key=key, data=value, etag='foo', metadata={'outbox.projection': 'true'}
+                ),
                 TransactionalStateOperation(key=another_key, data=another_value),
             ],
             transactional_metadata={'metakey': 'metavalue'},
         )
+
+        self.assertEqual(
+            self._fake_dapr_server.transaction_operation_metadata[key],
+            {'outbox.projection': 'true'},
+        )
+        self.assertEqual(self._fake_dapr_server.transaction_operation_metadata[another_key], {})
 
         resp = await dapr.get_bulk_state(store_name='statestore', keys=[key, another_key])
         self.assertEqual(resp.items[0].key, key)


### PR DESCRIPTION
# Description

Pass per-operation `StateItem` metadata in the async client's `execute_state_transaction`, mirroring the sync client (#791). Without, per-op metadata e.g. `outbox.projection` for the transactional outbox is silently dropped, so both operations get published and the projection payload overwrites the state value.

## Issue reference
#1131 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
