### PR TITLE
Make dependabot ignore grpcio-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,25 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      # MAINTAINERS: do not bump grpcio-tools like a normal dev dependency.
+      # Its pinned version must stay the one that generated the committed files
+      # under dapr/proto/. Regenerating with a newer version raises the minimum
+      # grpcio/protobuf that SDK users are able to install. Leaving it alone is
+      # always safe: old generated code works with every newer runtime.
+      #
+      # Bump it only when one of these happens:
+      #   - our .proto files need a newer protoc to compile
+      #   - a newly supported Python version has no wheels for the current
+      #     grpcio/protobuf floor versions
+      #   - a security fix lands in protoc/grpc code generation
+      #   - a grpcio or protobuf major release forces a migration
+      #
+      # How to bump, all in one PR:
+      #   1. update the grpcio-tools pin in pyproject.toml
+      #   2. rerun tools/regen_grpcclient.sh and tools/regen_durabletask_protos.sh
+      #   3. raise the grpcio/protobuf floors in [project.dependencies]
+      # tests/test_proto_gencode_floor.py fails CI if these steps drift apart.
+      - dependency-name: "grpcio-tools"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,7 @@ When completing any task on this project, work through this checklist. Not every
 
 - **Namespace packages**: `dapr.ext` is a PEP 420 implicit namespace package. Do **not** create `dapr/ext/__init__.py`; that would block any future externally-published `dapr.ext.*` distribution from coexisting with the core wheel on install.
 - **Proto files**: Never manually edit anything under `dapr/proto/`. These are generated.
+- **Do not bump `grpcio-tools` like a normal dev dependency**: its pin must stay the version that generated the committed files under `dapr/proto/` — regenerating with a newer one raises the minimum `grpcio`/`protobuf` that SDK users can install, while leaving it alone is always safe. Dependabot is configured to ignore it; the comment in `.github/dependabot.yml` lists when a bump is justified and the 3-step recipe (pin + regen + floors, in one PR, enforced by `tests/test_proto_gencode_floor.py`).
 - **Bundled extensions**: live under `dapr/ext/<name>/`, opted in via extras (`dapr[fastapi]`, etc.). The legacy `dapr-ext-*` and `flask-dapr` distributions are no longer published; legacy installs must be uninstalled before upgrading or `import dapr` will emit a `FutureWarning`.
 - **DCO signoff**: PRs will be blocked by the DCO bot if commits lack `Signed-off-by`. Always use `git commit -s`.
 - **Ruff version pinned**: `pyproject.toml` pins `ruff==0.14.1` in `[dependency-groups].dev`. Use `uv sync --all-packages --group dev` to get the exact version.


### PR DESCRIPTION
# Description

Configures dependabot to ignore all `grpcio-tools` updates, and documents the bump
policy for maintainers (inline comment in `.github/dependabot.yml`, plus a Gotchas
bullet in `AGENTS.md`).

`grpcio-tools` is not a normal dev dependency: its pin must stay the version that
generated the committed gencode under `dapr/proto/`. The generated files embed
minimum `grpcio`/`protobuf` versions stamped at generation time, which users'
installs must satisfy at import — so regenerating with a newer grpcio-tools raises
the SDK's user-facing runtime floors. Holding the pin back costs nothing: old
gencode is fully supported on every newer runtime within the same major.

Dependabot's routine bump PRs are therefore noise at best, and at worst invite
merging a pin that no longer matches the committed gencode. This PR silences them.

Bumps remain possible, just deliberate. The new comment in `dependabot.yml` lists
the legitimate triggers (protos needing a newer protoc, a newly supported Python
version lacking wheels for the floor versions, a codegen security fix, or a
grpcio/protobuf major migration) and the recipe: update the pin, rerun the regen
scripts, and raise the floors in `[project.dependencies]`, all in one PR.
`tests/test_proto_gencode_floor.py` already fails CI if these drift apart.