### PR TITLE
Fix convert_to_dapr_duration double-counting sub-second time

### DIFF
--- a/dapr/serializers/util.py
+++ b/dapr/serializers/util.py
@@ -74,4 +74,7 @@ def convert_to_dapr_duration(td: timedelta) -> str:
     milliseconds, microseconds = divmod(td.microseconds, 1000.0)
     hours, mins = divmod(total_minutes, 60.0)
 
-    return f'{hours:.0f}h{mins:.0f}m{seconds:.0f}s{milliseconds:.0f}ms{microseconds:.0f}μs'
+    # `seconds` still carries the sub-second fraction, which is also emitted via
+    # the ms/μs fields below; truncate it so the fraction is not double-counted
+    # (and so a fraction >= 0.5 is not rounded up into an extra whole second).
+    return f'{hours:.0f}h{mins:.0f}m{int(seconds)}s{milliseconds:.0f}ms{microseconds:.0f}μs'

--- a/tests/serializers/test_util.py
+++ b/tests/serializers/test_util.py
@@ -63,6 +63,13 @@ class UtilTests(unittest.TestCase):
         )
         self.assertEqual(duration, '4h15m40s123ms35μs')
 
+    def test_convert_timedelta_to_dapr_duration_subsecond(self):
+        # A sub-second fraction >= 0.5 must not be rounded up into an extra whole
+        # second nor double-counted with the ms/μs fields; the round-trip must be exact.
+        duration = convert_to_dapr_duration(timedelta(milliseconds=1500))
+        self.assertEqual(duration, '0h0m1s500ms0μs')
+        self.assertEqual(convert_from_dapr_duration(duration), timedelta(milliseconds=1500))
+
     def test_convert_invalid_duration_string(self):
         TESTSTRING = '4h15m40s123ms35μshello'
         with self.assertRaises(ValueError) as exeception_context:


### PR DESCRIPTION
## Description

`convert_to_dapr_duration()` produces a Dapr duration string that is ~1 second too large for any `timedelta` whose sub-second part is `>= 0.5`.

```python
from datetime import timedelta
from dapr.serializers.util import convert_to_dapr_duration, convert_from_dapr_duration

convert_to_dapr_duration(timedelta(milliseconds=1500))
# -> '0h0m2s500ms0μs'   (2.5s, expected 1.5s)
convert_from_dapr_duration('0h0m2s500ms0μs')
# -> timedelta(seconds=2, microseconds=500000)   # round-trip is off by 1s
```

The `seconds` field comes from `divmod(td.total_seconds(), 60)`, so it still carries the sub-second fraction — which is *also* emitted via the `ms`/`μs` fields (from `td.microseconds`). Formatting it with `{:.0f}` then rounds a fraction `>= 0.5` up into an extra whole second, so the fraction is both double-counted and rounded.

This is on the serialization hot path (`DaprJSONEncoder` serializes every `timedelta`), so any duration with a `>= 0.5s` fraction — e.g. actor timer/reminder periods or state TTLs — is encoded incorrectly.

## Fix

Truncate the whole-seconds field with `int()` so the sub-second fraction is only counted once (via the `ms`/`μs` fields). `hours`/`mins` are always whole, so only `seconds` needs this.

## Tests

Added `test_convert_timedelta_to_dapr_duration_subsecond` in `tests/serializers/test_util.py` (asserts the exact string and an exact round-trip). It fails before this change and passes after. Existing tests, `ruff`, and `mypy` all pass.
